### PR TITLE
feat: Add Markdown link checker and runtime tests (#14)

### DIFF
--- a/.github/workflows/validate-engine.yml
+++ b/.github/workflows/validate-engine.yml
@@ -31,6 +31,7 @@ jobs:
       - run: node scripts/validate-engine.mjs
       - run: node scripts/build-plugin-packages.mjs --clean
       - run: node scripts/validate-plugin-packages.mjs
+      - run: node scripts/check-markdown-links.mjs
       - run: npm ci
         working-directory: demo-pricing
       - run: npm run build

--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+const rootFiles = [
+  "README.md",
+  "README-KR.md",
+  "CONTRIBUTING.md",
+  "ROADMAP.md",
+];
+
+const scanDirectories = ["engine", "docs"];
+
+function collectMarkdownFiles(directory) {
+  if (!existsSync(directory)) {
+    return [];
+  }
+
+  const files = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const filePath = resolve(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(filePath));
+    } else if (entry.isFile() && /\.md$/iu.test(entry.name)) {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+}
+
+function getMarkdownFiles(repositoryRoot) {
+  const files = [];
+
+  for (const file of rootFiles) {
+    const filePath = resolve(repositoryRoot, file);
+
+    if (existsSync(filePath)) {
+      files.push(filePath);
+    }
+  }
+
+  for (const directory of scanDirectories) {
+    files.push(
+      ...collectMarkdownFiles(resolve(repositoryRoot, directory))
+    );
+  }
+
+  return files;
+}
+
+function isIgnoredTarget(target) {
+  return (
+    target.startsWith("#") ||
+    /^https?:\/\//iu.test(target) ||
+    /^mailto:/iu.test(target)
+  );
+}
+
+function stripQueryAndFragment(target) {
+  return target.split(/[?#]/u, 1)[0];
+}
+
+function extractMarkdownLinks(content) {
+  const links = [];
+  const lines = content.split(/\r?\n/u);
+
+  let fenced = false;
+  let fenceCharacter = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const fence = line.match(/^\s*(`{3,}|~{3,})/u);
+
+    if (fence) {
+      const character = fence[1][0];
+
+      if (!fenced) {
+        fenced = true;
+        fenceCharacter = character;
+      } else if (character === fenceCharacter) {
+        fenced = false;
+        fenceCharacter = null;
+      }
+
+      continue;
+    }
+
+    if (fenced) {
+      continue;
+    }
+
+    const linkPattern =
+      /!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))/gu;
+
+    let match;
+
+    while ((match = linkPattern.exec(line)) !== null) {
+      links.push({
+        target: match[1] ?? match[2],
+        line: index + 1,
+      });
+    }
+  }
+
+  return links;
+}
+
+function resolveTarget(sourceFile, target, repositoryRoot) {
+  const localTarget = stripQueryAndFragment(target);
+
+  if (!localTarget) {
+    return null;
+  }
+
+  const decodedTarget = decodeURIComponent(localTarget);
+
+  // A leading slash is treated as repository-root-relative.
+  if (decodedTarget.startsWith("/")) {
+    return resolve(repositoryRoot, `.${decodedTarget}`);
+  }
+
+  return resolve(dirname(sourceFile), decodedTarget);
+}
+
+export function checkMarkdownLinks(repositoryRoot = root) {
+  const errors = [];
+
+  for (const sourceFile of getMarkdownFiles(repositoryRoot)) {
+    const content = readFileSync(sourceFile, "utf8");
+
+    for (const link of extractMarkdownLinks(content)) {
+      if (isIgnoredTarget(link.target)) {
+        continue;
+      }
+
+      const targetPath = resolveTarget(
+        sourceFile,
+        link.target,
+        repositoryRoot
+      );
+
+      if (!targetPath) {
+        continue;
+      }
+const relativeTarget = relative(repositoryRoot, targetPath);
+
+if (relativeTarget.startsWith("..")) {
+  continue;
+}
+      if (!existsSync(targetPath)) {
+        errors.push({
+          file: relative(repositoryRoot, sourceFile),
+          line: link.line,
+          target: link.target,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
+const isMain =
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  const errors = checkMarkdownLinks();
+
+  if (errors.length > 0) {
+    console.error("Broken Markdown links found:");
+
+    for (const error of errors) {
+      console.error(
+        `  ${error.file}:${error.line} -> ${error.target}`
+      );
+    }
+
+    process.exit(1);
+  }
+
+  console.log("Markdown links OK.");
+}

--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, relative, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
@@ -21,8 +21,11 @@ function collectMarkdownFiles(directory) {
   }
 
   const files = [];
+  const entries = readdirSync(directory, { withFileTypes: true }).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
-  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+  for (const entry of entries) {
     const filePath = resolve(directory, entry.name);
 
     if (entry.isDirectory()) {
@@ -47,9 +50,7 @@ function getMarkdownFiles(repositoryRoot) {
   }
 
   for (const directory of scanDirectories) {
-    files.push(
-      ...collectMarkdownFiles(resolve(repositoryRoot, directory))
-    );
+    files.push(...collectMarkdownFiles(resolve(repositoryRoot, directory)));
   }
 
   return files;
@@ -58,8 +59,8 @@ function getMarkdownFiles(repositoryRoot) {
 function isIgnoredTarget(target) {
   return (
     target.startsWith("#") ||
-    /^https?:\/\//iu.test(target) ||
-    /^mailto:/iu.test(target)
+    target.startsWith("//") ||
+    /^[a-z][a-z0-9+.-]*:/iu.test(target)
   );
 }
 
@@ -96,8 +97,7 @@ function extractMarkdownLinks(content) {
       continue;
     }
 
-    const linkPattern =
-      /!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))/gu;
+    const linkPattern = /!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))/gu;
 
     let match;
 
@@ -121,7 +121,6 @@ function resolveTarget(sourceFile, target, repositoryRoot) {
 
   const decodedTarget = decodeURIComponent(localTarget);
 
-  // A leading slash is treated as repository-root-relative.
   if (decodedTarget.startsWith("/")) {
     return resolve(repositoryRoot, `.${decodedTarget}`);
   }
@@ -140,20 +139,22 @@ export function checkMarkdownLinks(repositoryRoot = root) {
         continue;
       }
 
-      const targetPath = resolveTarget(
-        sourceFile,
-        link.target,
-        repositoryRoot
-      );
+      const targetPath = resolveTarget(sourceFile, link.target, repositoryRoot);
 
       if (!targetPath) {
         continue;
       }
-const relativeTarget = relative(repositoryRoot, targetPath);
 
-if (relativeTarget.startsWith("..")) {
-  continue;
-}
+      const relativeTarget = relative(repositoryRoot, targetPath);
+      const isOutsideRepository =
+        relativeTarget === ".." ||
+        relativeTarget.startsWith(`..${sep}`) ||
+        isAbsolute(relativeTarget);
+
+      if (isOutsideRepository) {
+        continue;
+      }
+
       if (!existsSync(targetPath)) {
         errors.push({
           file: relative(repositoryRoot, sourceFile),
@@ -178,9 +179,7 @@ if (isMain) {
     console.error("Broken Markdown links found:");
 
     for (const error of errors) {
-      console.error(
-        `  ${error.file}:${error.line} -> ${error.target}`
-      );
+      console.error(`  ${error.file}:${error.line} -> ${error.target}`);
     }
 
     process.exit(1);

--- a/scripts/runtime-tests/check-markdown-links.test.mjs
+++ b/scripts/runtime-tests/check-markdown-links.test.mjs
@@ -1,11 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  mkdtempSync,
-  mkdirSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { checkMarkdownLinks } from "../check-markdown-links.mjs";
@@ -16,28 +11,18 @@ function root(prefix) {
 
 test("markdown link checker accepts valid local targets", () => {
   const projectRoot = root("styleseed-links-valid-");
-
   try {
     mkdirSync(join(projectRoot, "docs"), { recursive: true });
-
-    writeFileSync(
-      join(projectRoot, "docs", "target.md"),
-      "# Target\n"
-    );
-
+    writeFileSync(join(projectRoot, "docs", "target.md"), "# Target\n");
     writeFileSync(
       join(projectRoot, "README.md"),
       [
         "[valid](docs/target.md)",
         "[query](docs/target.md?foo=bar)",
         "[fragment](docs/target.md#section)",
-      ].join("\n")
+      ].join("\n"),
     );
-
-    assert.deepEqual(
-      checkMarkdownLinks(projectRoot),
-      []
-    );
+    assert.deepEqual(checkMarkdownLinks(projectRoot), []);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -45,26 +30,16 @@ test("markdown link checker accepts valid local targets", () => {
 
 test("markdown link checker reports missing targets with source and line", () => {
   const projectRoot = root("styleseed-links-missing-");
-
   try {
     writeFileSync(
       join(projectRoot, "README.md"),
-      [
-        "# Example",
-        "",
-        "[missing](docs/does-not-exist.md)",
-      ].join("\n")
+      ["# Example", "", "[missing](docs/does-not-exist.md)"].join("\n"),
     );
-
     const errors = checkMarkdownLinks(projectRoot);
-
     assert.equal(errors.length, 1);
     assert.equal(errors[0].file, "README.md");
     assert.equal(errors[0].line, 3);
-    assert.equal(
-      errors[0].target,
-      "docs/does-not-exist.md"
-    );
+    assert.equal(errors[0].target, "docs/does-not-exist.md");
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -72,7 +47,6 @@ test("markdown link checker reports missing targets with source and line", () =>
 
 test("markdown link checker ignores external URLs and anchors", () => {
   const projectRoot = root("styleseed-links-external-");
-
   try {
     writeFileSync(
       join(projectRoot, "README.md"),
@@ -81,13 +55,9 @@ test("markdown link checker ignores external URLs and anchors", () => {
         "[HTTP](http://example.com)",
         "[Email](mailto:test@example.com)",
         "[Anchor](#section)",
-      ].join("\n")
+      ].join("\n"),
     );
-
-    assert.deepEqual(
-      checkMarkdownLinks(projectRoot),
-      []
-    );
+    assert.deepEqual(checkMarkdownLinks(projectRoot), []);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -95,15 +65,9 @@ test("markdown link checker ignores external URLs and anchors", () => {
 
 test("markdown link checker ignores links inside fenced code blocks", () => {
   const projectRoot = root("styleseed-links-fenced-");
-
   try {
     mkdirSync(join(projectRoot, "docs"), { recursive: true });
-
-    writeFileSync(
-      join(projectRoot, "docs", "target.md"),
-      "# Target\n"
-    );
-
+    writeFileSync(join(projectRoot, "docs", "target.md"), "# Target\n");
     writeFileSync(
       join(projectRoot, "README.md"),
       [
@@ -112,13 +76,53 @@ test("markdown link checker ignores links inside fenced code blocks", () => {
         "```",
         "",
         "[valid](docs/target.md)",
-      ].join("\n")
+      ].join("\n"),
     );
+    assert.deepEqual(checkMarkdownLinks(projectRoot), []);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
 
-    assert.deepEqual(
-      checkMarkdownLinks(projectRoot),
-      []
+test("markdown link checker ignores non-http(s) URI schemes and network-path references", () => {
+  const projectRoot = root("styleseed-links-schemes-");
+  try {
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      [
+        "[FTP](ftp://example.com/file.md)",
+        "[Network path](//cdn.example.com/image.png)",
+      ].join("\n"),
     );
+    assert.deepEqual(checkMarkdownLinks(projectRoot), []);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("markdown link checker still resolves single-leading-slash repository-root links", () => {
+  const projectRoot = root("styleseed-links-root-relative-");
+  try {
+    mkdirSync(join(projectRoot, "docs"), { recursive: true });
+    writeFileSync(join(projectRoot, "docs", "target.md"), "# Target\n");
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      "[root relative](/docs/target.md)\n",
+    );
+    assert.deepEqual(checkMarkdownLinks(projectRoot), []);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("markdown link checker reports an in-repository target that merely starts with '..'", () => {
+  const projectRoot = root("styleseed-links-dotdot-prefix-");
+  try {
+    writeFileSync(join(projectRoot, "README.md"), "[missing](..missing.md)\n");
+    const errors = checkMarkdownLinks(projectRoot);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].file, "README.md");
+    assert.equal(errors[0].target, "..missing.md");
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -126,13 +130,8 @@ test("markdown link checker ignores links inside fenced code blocks", () => {
 
 test("markdown link checker ignores targets outside the repository", () => {
   const projectRoot = root("styleseed-links-outside-");
-
   try {
-    writeFileSync(
-      join(projectRoot, "README.md"),
-      "[Wiki](../../wiki)\n"
-    );
-
+    writeFileSync(join(projectRoot, "README.md"), "[Wiki](../../wiki)\n");
     assert.deepEqual(checkMarkdownLinks(projectRoot), []);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });

--- a/scripts/runtime-tests/check-markdown-links.test.mjs
+++ b/scripts/runtime-tests/check-markdown-links.test.mjs
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkMarkdownLinks } from "../check-markdown-links.mjs";
+
+function root(prefix) {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+test("markdown link checker accepts valid local targets", () => {
+  const projectRoot = root("styleseed-links-valid-");
+
+  try {
+    mkdirSync(join(projectRoot, "docs"), { recursive: true });
+
+    writeFileSync(
+      join(projectRoot, "docs", "target.md"),
+      "# Target\n"
+    );
+
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      [
+        "[valid](docs/target.md)",
+        "[query](docs/target.md?foo=bar)",
+        "[fragment](docs/target.md#section)",
+      ].join("\n")
+    );
+
+    assert.deepEqual(
+      checkMarkdownLinks(projectRoot),
+      []
+    );
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("markdown link checker reports missing targets with source and line", () => {
+  const projectRoot = root("styleseed-links-missing-");
+
+  try {
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      [
+        "# Example",
+        "",
+        "[missing](docs/does-not-exist.md)",
+      ].join("\n")
+    );
+
+    const errors = checkMarkdownLinks(projectRoot);
+
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].file, "README.md");
+    assert.equal(errors[0].line, 3);
+    assert.equal(
+      errors[0].target,
+      "docs/does-not-exist.md"
+    );
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("markdown link checker ignores external URLs and anchors", () => {
+  const projectRoot = root("styleseed-links-external-");
+
+  try {
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      [
+        "[GitHub](https://github.com/example/project)",
+        "[HTTP](http://example.com)",
+        "[Email](mailto:test@example.com)",
+        "[Anchor](#section)",
+      ].join("\n")
+    );
+
+    assert.deepEqual(
+      checkMarkdownLinks(projectRoot),
+      []
+    );
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("markdown link checker ignores links inside fenced code blocks", () => {
+  const projectRoot = root("styleseed-links-fenced-");
+
+  try {
+    mkdirSync(join(projectRoot, "docs"), { recursive: true });
+
+    writeFileSync(
+      join(projectRoot, "docs", "target.md"),
+      "# Target\n"
+    );
+
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      [
+        "```md",
+        "[missing](docs/does-not-exist.md)",
+        "```",
+        "",
+        "[valid](docs/target.md)",
+      ].join("\n")
+    );
+
+    assert.deepEqual(
+      checkMarkdownLinks(projectRoot),
+      []
+    );
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("markdown link checker ignores targets outside the repository", () => {
+  const projectRoot = root("styleseed-links-outside-");
+
+  try {
+    writeFileSync(
+      join(projectRoot, "README.md"),
+      "[Wiki](../../wiki)\n"
+    );
+
+    assert.deepEqual(checkMarkdownLinks(projectRoot), []);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Change

Add a dependency-free Markdown link checker that validates repository-local file and image targets in maintained Markdown files.

The checker:

* Scans `README.md`, `README-KR.md`, `CONTRIBUTING.md`, and `ROADMAP.md`.
* Recursively checks maintained Markdown under `engine/` and `docs/`.
* Strips query strings and fragments before checking local targets.
* Ignores external URLs, `mailto:` links, hash-only anchors, and fenced code examples.
* Reports the source file, line number, and missing target.
* Exits non-zero when a local target is missing.

Added focused runtime tests covering valid targets, missing targets, external URLs/anchors, query/fragment suffixes, and fenced code blocks.

## Related issue

Closes #14 

## Evidence

```text
node scripts/check-markdown-links.mjs -> Markdown links OK.

node --test scripts/runtime-tests/check-markdown-links.test.mjs -> 5 tests passed, 0 failed

git diff --check -> passed
```
<img width="861" height="317" alt="image" src="https://github.com/user-attachments/assets/c06e251e-ddf1-44f1-bb35-1924524889f4" />

## Example of a broken link
<img width="730" height="62" alt="image" src="https://github.com/user-attachments/assets/659830b5-4e6e-49c5-a62e-b51d67e32681" />

## Type

* [ ] Documentation, example, or translation
* [ ] Regression fixture or bug fix
* [ ] Design rule or palette
* [ ] Skin, component, or pattern
* [ ] Grammar or adapter
* [x] Agent skill or packaging
* [x] Other tooling

## Checklist

* [x] I changed the maintained source rather than only a generated mirror.
* [x] I ran the smallest relevant checks from `CONTRIBUTING.md`.
* [x] I reviewed every changed line, including AI-assisted output.
* [x] I attached current rendered evidence when pixels or interaction changed.
* [x] I kept version, release, and deployment files unchanged unless explicitly requested.

