### PR TITLE
docs: verify Windows PowerShell install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ The fastest path is at the top — [paste one prompt](#easy-start-30-seconds), o
 > **New to this? Read top to bottom — every step matters.** The most common
 > mistake is expecting setup to work before the skill is installed. Claude
 > Code scans `.claude/skills/`; Codex scans `.agents/skills/`.
+> Windows users can follow the copy-pasteable [PowerShell verification path](docs/WINDOWS-INSTALL.md).
 
 ### Option 1: Interactive Setup (Recommended)
 

--- a/docs/WINDOWS-INSTALL.md
+++ b/docs/WINDOWS-INSTALL.md
@@ -1,0 +1,117 @@
+# Verify a StyleSeed install on Windows PowerShell
+
+This is a project-local verification path for the public core distribution. It does not install
+the optional learning extension or a StyleSeed MCP server.
+
+## Verified environment
+
+The commands below were verified on 2026-08-25 with:
+
+- Windows 10.0.19045.7663
+- PowerShell 7.6.4
+- Node.js 22.23.2
+- npm / npx 10.9.8
+- `skills` CLI 1.5.23
+- Codex desktop 26.818.8289.0
+- StyleSeed 4.1.0 at commit `f064c75`
+
+## Clean project-local install
+
+Open PowerShell in a disposable, non-sensitive parent directory. Create a clean workspace and
+confirm the runtime versions:
+
+```powershell
+$workspace = Join-Path $PWD "styleseed-windows-check"
+New-Item -ItemType Directory -Path $workspace | Out-Null
+Set-Location $workspace
+
+node --version
+npx --version
+$PSVersionTable | Select-Object PSVersion, PSEdition, Platform, OS
+```
+
+Expected version output starts with Node.js `v22` and identifies Windows (`Win32NT`). Then run the
+public install command:
+
+```powershell
+npx skills add bitjaru/styleseed
+```
+
+When `npx` asks to install the `skills` package, review the displayed version and approve it. In the
+verified Codex environment the installer reported:
+
+```text
+codex  Agent detected — installing non-interactively
+Source: https://github.com/bitjaru/styleseed.git
+Installed 23 skills
+```
+
+The result is project-local under `.agents\skills`; no administrator shell or global install is
+required.
+
+## Verify the core and router
+
+Count and list the installed skills:
+
+```powershell
+$skillRoot = Join-Path $PWD ".agents\skills"
+$skills = Get-ChildItem -LiteralPath $skillRoot -Directory
+
+$skills.Count
+$skills.Name | Sort-Object
+```
+
+Expected count:
+
+```text
+23
+```
+
+Confirm the `styleseed` router and installed StyleSeed version:
+
+```powershell
+$router = Join-Path $skillRoot "styleseed\SKILL.md"
+Test-Path -LiteralPath $router
+Get-Content -LiteralPath $router -TotalCount 4
+
+$catalogPath = Join-Path $skillRoot "ss-resolve\references\catalog.json"
+(Get-Content -Raw -LiteralPath $catalogPath | ConvertFrom-Json).engineVersion
+```
+
+Expected output includes:
+
+```text
+True
+name: styleseed
+4.1.0
+```
+
+For Codex discovery, start a fresh Codex session in this workspace, open `/skills`, and choose
+`styleseed`, or invoke `$styleseed`. The installer detecting Codex and the router existing at
+`.agents\skills\styleseed\SKILL.md` verify the host path. An already-running session may retain its
+old skill index; needing a fresh session is a host refresh limitation, not an install failure.
+
+## Confirm excluded components
+
+The public core should not contain `ss-learn`, a StyleSeed MCP server, or a plugin package:
+
+```powershell
+Test-Path -LiteralPath (Join-Path $skillRoot "ss-learn")
+
+Get-ChildItem -LiteralPath $PWD -Recurse -Force |
+  Where-Object { $_.Name -match '(^ss-learn$|mcp|plugin\.json|\.codex-plugin)' } |
+  Select-Object -ExpandProperty FullName
+```
+
+Expected output is `False` for `ss-learn` and no paths from the second command.
+
+## Troubleshooting
+
+- **The skill count is not 23:** confirm that the command ran in the intended empty workspace and
+  that `$skillRoot` is `.agents\skills`. Remove or replace files only after reviewing them.
+- **`styleseed` is missing from Codex:** confirm the router file exists, then start a fresh Codex
+  session in the workspace. Discovery is session-scoped.
+- **PowerShell blocks `npx.ps1`:** run `npx.cmd skills add bitjaru/styleseed`. This uses the same npm
+  executable without changing the machine execution policy.
+- **The clone or package download fails:** check GitHub and npm network access, then retry. A network
+  or proxy failure is separate from StyleSeed core validation.

--- a/scripts/test-public-claims.mjs
+++ b/scripts/test-public-claims.mjs
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const root = resolve(new URL("../", import.meta.url).pathname);
+const root = fileURLToPath(new URL("../", import.meta.url));
 const files = [
   "README.md",
   "README-KR.md",


### PR DESCRIPTION
## Change

- Add a copy-pasteable Windows PowerShell install and verification guide.
- Link the guide from the README manual-install section.
- Make the public-claims validator path-safe on Windows with `fileURLToPath()`.

## Related issue

Closes #13.

## Evidence

Verified on 2026-08-25 with:

- Windows 10.0.19045.7663
- PowerShell 7.6.4
- Node.js 22.23.2
- npm / npx 10.9.8
- `skills` CLI 1.5.23
- Codex desktop 26.818.8289.0
- StyleSeed 4.1.0 at `f064c75`

Representative redacted output:

```text
codex  Agent detected — installing non-interactively
Source: https://github.com/bitjaru/styleseed.git
Found 23 skills
Installed 23 skills

SKILL_ROOT_PRESENT=True
SKILL_COUNT=23
ROUTER_PRESENT=True
name: styleseed
ENGINE_VERSION=4.1.0
ENGINE_REVISION=sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772
SS_LEARN_PRESENT=False
EXCLUDED_MATCH_COUNT=0
```

The fresh checkout used `core.symlinks=true`; `.agents/skills` was a symbolic link. Checkout policy verification:

```text
i/lf    w/lf    attr/text=auto eol=lf    scripts/validate-skill-contracts.mjs
```

Required checks:

```text
node scripts/test-public-claims.mjs  PASS
node scripts/validate-engine.mjs     PASS
git diff --check                     PASS
```

## Type

- [x] Documentation, example, or translation
- [x] Regression fixture or bug fix
- [ ] Design rule or palette
- [ ] Skin, component, or pattern
- [ ] Grammar or adapter
- [ ] Agent skill or packaging
- [ ] Other tooling

## Checklist

- [x] I changed the maintained source rather than only a generated mirror.
- [x] I ran the smallest relevant checks from `CONTRIBUTING.md`.
- [x] I reviewed every changed line, including AI-assisted output.
- [x] Visual evidence is not applicable to this documentation/path-handling change.
- [x] I kept version, release, and deployment files unchanged.

Scope is limited to `README.md`, `docs/WINDOWS-INSTALL.md`, and `scripts/test-public-claims.mjs`.