### PR TITLE
Closes #16: Docs: add a copy-paste document-report adapter lock example

### DIFF
--- a/demo-pricing/public/.well-known/styleseed/context-catalog.json
+++ b/demo-pricing/public/.well-known/styleseed/context-catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
   "distributions": {
     "core": {
-      "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+      "revision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
       "files": [
         {
           "path": "LICENSE",
@@ -278,8 +278,8 @@
         },
         {
           "path": "engine/ADAPTERS.md",
-          "sha256": "e9f295540d331a517edbf956a1549d24077943cccc7b54532e9a1f7255380d7f",
-          "bytes": 5921
+          "sha256": "990bc5292b02cd09d52abbadd2168eba6d8cc0b4bc2edba2611602e0ebd8d856",
+          "bytes": 6960
         },
         {
           "path": "engine/AGENTS.md",
@@ -942,8 +942,8 @@
     },
     {
       "path": "ADAPTERS.md",
-      "sha256": "e9f295540d331a517edbf956a1549d24077943cccc7b54532e9a1f7255380d7f",
-      "bytes": 5921
+      "sha256": "990bc5292b02cd09d52abbadd2168eba6d8cc0b4bc2edba2611602e0ebd8d856",
+      "bytes": 6960
     },
     {
       "path": "AGENTS.md",
@@ -1099,7 +1099,7 @@
     "product-ui": "## `product-ui`\n\n- **Canvas:** responsive viewports declared in the design lock; verify at least one narrow and\n  one wide target when both are in scope.\n- **Primitives:** semantic HTML and project-native components. Preserve framework conventions,\n  routes, state, and real content rather than replacing the application with a mock.\n- **States:** loading, empty, error, success, disabled, focus, and responsive navigation are part\n  of the artifact when the screen owns those behaviors.\n- **Export:** source code plus reproducible dev/build commands and screenshot paths.\n- **QA:** run project checks, render the real route, inspect target viewports and important states,\n  and record what could not be exercised.",
     "social-carousel": "## `social-carousel`\n\nUse `sequential-story` unless another grammar clearly owns the content. The installed Claude\n`carousel-build` skill is the canonical companion when available:\n\n1. StyleSeed reads or compiles the grammar and writes brand/type/motion/content rules to\n   `STYLESEED.md`.\n2. `carousel-build` reads that lock, then applies deterministic engineering constraints:\n   3:4 `1080×1440`, platform safe zones, crop behavior, 8px rhythm, type scale, gradient\n   banding prevention, available font weights, and reproducible PIL rendering.\n3. Copy and publishing skills may add their own contracts without altering visual authority.\n4. `/ss-score` checks sequence coherence and grammar fit; `/ss-verify` opens every exported\n   frame and checks crop, safe zone, typography, rhythm, false text, and continuity.\n\nRecommended lock additions:\n\n```markdown\n- Surface adapter: social-carousel\n- Artifact type: information-carousel\n- Canvas: 1080x1440\n- Sequence grammar: hook → why → evidence → action → reframe → CTA\n- Renderer: carousel-build\n- Safe zone contract: adapter:ADAPTERS.md#social-carousel-integration\n```\n\nDo not duplicate the renderer's rapidly changing platform measurements inside a visual grammar.\nThe adapter/companion owns them; StyleSeed owns the visual judgment applied within them.",
     "slide-deck": "## `slide-deck`\n\n- **Canvas:** use the presentation renderer's declared aspect ratio and safe area. Assume distance\n  viewing; body copy that works on a web page is usually too small or dense on a slide.\n- **Sequence:** one claim per slide, visible narrative progression, and deliberate alternation\n  between statement, evidence, comparison, and action.\n- **Assets:** use real charts, diagrams, screenshots, and cited imagery. Never use a text-heavy\n  card grid as a substitute for a presentation.\n- **Export:** editable deck plus rendered PDF or page images.\n- **QA:** render every slide, inspect overflow and contrast, and compare repeated masters,\n  alignment, folios, and speaker-facing information.",
-    "document-report": "## `document-report`\n\n- **Canvas:** paginated output with explicit paper size, margins, headers/footers, and print-safe\n  color. Reading measure and page breaks take priority over app-like chrome.\n- **Structure:** title and executive summary establish the decision; headings, figures, tables,\n  notes, and appendices expose evidence at the right depth.\n- **Assets:** captions and sources remain attached to figures and tables. Repeated components use\n  document styles rather than local formatting.\n- **Export:** editable source plus visually verified PDF.\n- **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,\n  accessibility structure, and cross-page consistency.",
+    "document-report": "## `document-report`\n\n- **Canvas:** paginated output with explicit paper size, margins, headers/footers, and print-safe\n  color. Reading measure and page breaks take priority over app-like chrome.\n- **Structure:** title and executive summary establish the decision; headings, figures, tables,\n  notes, and appendices expose evidence at the right depth.\n- **Assets:** captions and sources remain attached to figures and tables. Repeated components use\n  document styles rather than local formatting.\n- **Export:** editable source plus visually verified PDF.\n- **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,\n  accessibility structure, and cross-page consistency.\n\nRecommended lock additions:\n\n```markdown\n- Surface adapter: document-report\n- Artifact type: research-report\n- Paper size: Letter\n- Margins: 0.75in top/bottom, 0.85in inner/outer\n- Header/footer: report title in header, section label optional, page number in footer\n- Reading measure: 60-75 characters for body text\n- Renderer: document/PDF renderer\n- Editable source: DOCX or structured source document\n- PDF export: required\n- Render evidence: page-by-page PDF images or screenshots\n- QA checks: widows/orphans, clipped tables, links, page numbers, accessibility structure\n- Physical output contract: renderer owns pagination, paper metrics, export fidelity, and PDF tags\n```\n\nFailing example:\n\n```markdown\n- Surface adapter: document-report\n- Layout assumption: reuse responsive web cards and let content scroll vertically\n```\n\nPaginated reports do not inherit web viewport assumptions. StyleSeed owns the report hierarchy,\nreading rhythm, and visual judgment; the renderer owns page boundaries, margins, flow, and export\nconstraints.",
     "single-frame": "## `single-frame`\n\n- **Canvas:** declare exact dimensions, crop variants, safe zones, and intended viewing distance.\n- **Composition:** one dominant message and one supporting action or proof. The frame must work\n  without surrounding caption text unless the publishing contract says otherwise.\n- **Assets:** logos, product imagery, and text are deterministic and legible. Generated imagery\n  must not supply final logos or critical text.\n- **Export:** source plus final PNG/JPEG/SVG variants and an asset manifest.\n- **QA:** inspect at native size and thumbnail size, verify crop variants, contrast, text safety,\n  and platform compression risk."
   },
   "domains": {

--- a/demo-pricing/public/.well-known/styleseed/registry.json
+++ b/demo-pricing/public/.well-known/styleseed/registry.json
@@ -20,7 +20,7 @@
   },
   "context": {
     "engineVersion": "4.1.0",
-    "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+    "engineRevision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
     "resolverSkill": "https://raw.githubusercontent.com/bitjaru/styleseed/main/engine/.claude/skills/ss-resolve/SKILL.md",
     "catalogUrl": "https://styleseed-demo.vercel.app/.well-known/styleseed/context-catalog.json",
     "grammarIds": [

--- a/demo-pricing/public/llms-full.txt
+++ b/demo-pricing/public/llms-full.txt
@@ -607,6 +607,34 @@ The adapter/companion owns them; StyleSeed owns the visual judgment applied with
 - **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,
   accessibility structure, and cross-page consistency.
 
+Recommended lock additions:
+
+```markdown
+- Surface adapter: document-report
+- Artifact type: research-report
+- Paper size: Letter
+- Margins: 0.75in top/bottom, 0.85in inner/outer
+- Header/footer: report title in header, section label optional, page number in footer
+- Reading measure: 60-75 characters for body text
+- Renderer: document/PDF renderer
+- Editable source: DOCX or structured source document
+- PDF export: required
+- Render evidence: page-by-page PDF images or screenshots
+- QA checks: widows/orphans, clipped tables, links, page numbers, accessibility structure
+- Physical output contract: renderer owns pagination, paper metrics, export fidelity, and PDF tags
+```
+
+Failing example:
+
+```markdown
+- Surface adapter: document-report
+- Layout assumption: reuse responsive web cards and let content scroll vertically
+```
+
+Paginated reports do not inherit web viewport assumptions. StyleSeed owns the report hierarchy,
+reading rhythm, and visual judgment; the renderer owns page boundaries, margins, flow, and export
+constraints.
+
 ## `single-frame`
 
 - **Canvas:** declare exact dimensions, crop variants, safe zones, and intended viewing distance.

--- a/demo-pricing/public/version.json
+++ b/demo-pricing/public/version.json
@@ -8,7 +8,7 @@
   "publicInstall": "npx skills add bitjaru/styleseed",
   "codexPackageStatus": "repository development Codex package",
   "version": "4.1.0",
-  "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "revision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
   "revisionFiles": 80,
   "skillsRevision": "sha256:4eab915c29fa928487d3f93bfcf7802fb887ab9f68202139cde7444db72578a1",
   "skillsRevisionFiles": 51,

--- a/engine/.claude/skills/ss-resolve/references/catalog.json
+++ b/engine/.claude/skills/ss-resolve/references/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
   "distributions": {
     "core": {
-      "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+      "revision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
       "files": [
         {
           "path": "LICENSE",
@@ -278,8 +278,8 @@
         },
         {
           "path": "engine/ADAPTERS.md",
-          "sha256": "e9f295540d331a517edbf956a1549d24077943cccc7b54532e9a1f7255380d7f",
-          "bytes": 5921
+          "sha256": "990bc5292b02cd09d52abbadd2168eba6d8cc0b4bc2edba2611602e0ebd8d856",
+          "bytes": 6960
         },
         {
           "path": "engine/AGENTS.md",
@@ -942,8 +942,8 @@
     },
     {
       "path": "ADAPTERS.md",
-      "sha256": "e9f295540d331a517edbf956a1549d24077943cccc7b54532e9a1f7255380d7f",
-      "bytes": 5921
+      "sha256": "990bc5292b02cd09d52abbadd2168eba6d8cc0b4bc2edba2611602e0ebd8d856",
+      "bytes": 6960
     },
     {
       "path": "AGENTS.md",
@@ -1099,7 +1099,7 @@
     "product-ui": "## `product-ui`\n\n- **Canvas:** responsive viewports declared in the design lock; verify at least one narrow and\n  one wide target when both are in scope.\n- **Primitives:** semantic HTML and project-native components. Preserve framework conventions,\n  routes, state, and real content rather than replacing the application with a mock.\n- **States:** loading, empty, error, success, disabled, focus, and responsive navigation are part\n  of the artifact when the screen owns those behaviors.\n- **Export:** source code plus reproducible dev/build commands and screenshot paths.\n- **QA:** run project checks, render the real route, inspect target viewports and important states,\n  and record what could not be exercised.",
     "social-carousel": "## `social-carousel`\n\nUse `sequential-story` unless another grammar clearly owns the content. The installed Claude\n`carousel-build` skill is the canonical companion when available:\n\n1. StyleSeed reads or compiles the grammar and writes brand/type/motion/content rules to\n   `STYLESEED.md`.\n2. `carousel-build` reads that lock, then applies deterministic engineering constraints:\n   3:4 `1080×1440`, platform safe zones, crop behavior, 8px rhythm, type scale, gradient\n   banding prevention, available font weights, and reproducible PIL rendering.\n3. Copy and publishing skills may add their own contracts without altering visual authority.\n4. `/ss-score` checks sequence coherence and grammar fit; `/ss-verify` opens every exported\n   frame and checks crop, safe zone, typography, rhythm, false text, and continuity.\n\nRecommended lock additions:\n\n```markdown\n- Surface adapter: social-carousel\n- Artifact type: information-carousel\n- Canvas: 1080x1440\n- Sequence grammar: hook → why → evidence → action → reframe → CTA\n- Renderer: carousel-build\n- Safe zone contract: adapter:ADAPTERS.md#social-carousel-integration\n```\n\nDo not duplicate the renderer's rapidly changing platform measurements inside a visual grammar.\nThe adapter/companion owns them; StyleSeed owns the visual judgment applied within them.",
     "slide-deck": "## `slide-deck`\n\n- **Canvas:** use the presentation renderer's declared aspect ratio and safe area. Assume distance\n  viewing; body copy that works on a web page is usually too small or dense on a slide.\n- **Sequence:** one claim per slide, visible narrative progression, and deliberate alternation\n  between statement, evidence, comparison, and action.\n- **Assets:** use real charts, diagrams, screenshots, and cited imagery. Never use a text-heavy\n  card grid as a substitute for a presentation.\n- **Export:** editable deck plus rendered PDF or page images.\n- **QA:** render every slide, inspect overflow and contrast, and compare repeated masters,\n  alignment, folios, and speaker-facing information.",
-    "document-report": "## `document-report`\n\n- **Canvas:** paginated output with explicit paper size, margins, headers/footers, and print-safe\n  color. Reading measure and page breaks take priority over app-like chrome.\n- **Structure:** title and executive summary establish the decision; headings, figures, tables,\n  notes, and appendices expose evidence at the right depth.\n- **Assets:** captions and sources remain attached to figures and tables. Repeated components use\n  document styles rather than local formatting.\n- **Export:** editable source plus visually verified PDF.\n- **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,\n  accessibility structure, and cross-page consistency.",
+    "document-report": "## `document-report`\n\n- **Canvas:** paginated output with explicit paper size, margins, headers/footers, and print-safe\n  color. Reading measure and page breaks take priority over app-like chrome.\n- **Structure:** title and executive summary establish the decision; headings, figures, tables,\n  notes, and appendices expose evidence at the right depth.\n- **Assets:** captions and sources remain attached to figures and tables. Repeated components use\n  document styles rather than local formatting.\n- **Export:** editable source plus visually verified PDF.\n- **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,\n  accessibility structure, and cross-page consistency.\n\nRecommended lock additions:\n\n```markdown\n- Surface adapter: document-report\n- Artifact type: research-report\n- Paper size: Letter\n- Margins: 0.75in top/bottom, 0.85in inner/outer\n- Header/footer: report title in header, section label optional, page number in footer\n- Reading measure: 60-75 characters for body text\n- Renderer: document/PDF renderer\n- Editable source: DOCX or structured source document\n- PDF export: required\n- Render evidence: page-by-page PDF images or screenshots\n- QA checks: widows/orphans, clipped tables, links, page numbers, accessibility structure\n- Physical output contract: renderer owns pagination, paper metrics, export fidelity, and PDF tags\n```\n\nFailing example:\n\n```markdown\n- Surface adapter: document-report\n- Layout assumption: reuse responsive web cards and let content scroll vertically\n```\n\nPaginated reports do not inherit web viewport assumptions. StyleSeed owns the report hierarchy,\nreading rhythm, and visual judgment; the renderer owns page boundaries, margins, flow, and export\nconstraints.",
     "single-frame": "## `single-frame`\n\n- **Canvas:** declare exact dimensions, crop variants, safe zones, and intended viewing distance.\n- **Composition:** one dominant message and one supporting action or proof. The frame must work\n  without surrounding caption text unless the publishing contract says otherwise.\n- **Assets:** logos, product imagery, and text are deterministic and legible. Generated imagery\n  must not supply final logos or critical text.\n- **Export:** source plus final PNG/JPEG/SVG variants and an asset manifest.\n- **QA:** inspect at native size and thumbnail size, verify crop variants, contrast, text safety,\n  and platform compression risk."
   },
   "domains": {

--- a/engine/ADAPTERS.md
+++ b/engine/ADAPTERS.md
@@ -97,6 +97,34 @@ The adapter/companion owns them; StyleSeed owns the visual judgment applied with
 - **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,
   accessibility structure, and cross-page consistency.
 
+Recommended lock additions:
+
+```markdown
+- Surface adapter: document-report
+- Artifact type: research-report
+- Paper size: Letter
+- Margins: 0.75in top/bottom, 0.85in inner/outer
+- Header/footer: report title in header, section label optional, page number in footer
+- Reading measure: 60-75 characters for body text
+- Renderer: document/PDF renderer
+- Editable source: DOCX or structured source document
+- PDF export: required
+- Render evidence: page-by-page PDF images or screenshots
+- QA checks: widows/orphans, clipped tables, links, page numbers, accessibility structure
+- Physical output contract: renderer owns pagination, paper metrics, export fidelity, and PDF tags
+```
+
+Failing example:
+
+```markdown
+- Surface adapter: document-report
+- Layout assumption: reuse responsive web cards and let content scroll vertically
+```
+
+Paginated reports do not inherit web viewport assumptions. StyleSeed owns the report hierarchy,
+reading rhythm, and visual judgment; the renderer owns page boundaries, margins, flow, and export
+constraints.
+
 ## `single-frame`
 
 - **Canvas:** declare exact dimensions, crop variants, safe zones, and intended viewing distance.

--- a/extensions/learning/runtime/catalog.json
+++ b/extensions/learning/runtime/catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
   "grammars": {
     "commerce-conversion": true,
     "consumer-service": true,

--- a/extensions/learning/runtime/references/learning-catalog.json
+++ b/extensions/learning/runtime/references/learning-catalog.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "contractVersion": 2,
   "scannerVersion": 2,
-  "revision": "sha256:3e72cdd42ab24ccc0902b90289fa155f2724a5996e53d6de3e3497dcb52887a2",
+  "revision": "sha256:5587de4f33f5f1ef52c293141bdcb9b7d6ea1d4fe0a7fc1c41a92b9fa46295b8",
   "files": [
     {
       "path": "extensions/learning/runtime/catalog.json",
-      "sha256": "sha256:60824deaa87d5ff3c989d3670f52d26912b75da8c16eed1e6ef2ccf8bb252d4e"
+      "sha256": "sha256:fde47feeae65742e68a5ac5d196b3b11de8509529f124399b4fec9dc90198026"
     },
     {
       "path": "extensions/learning/skills/ss-learn/scripts/learning-contract.mjs",

--- a/skills/ss-resolve/references/catalog.json
+++ b/skills/ss-resolve/references/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
   "distributions": {
     "core": {
-      "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+      "revision": "sha256:b2b727c871aefbde83aa8decffa56695760a22a265b524eabf1d2982b83cb078",
       "files": [
         {
           "path": "LICENSE",
@@ -278,8 +278,8 @@
         },
         {
           "path": "engine/ADAPTERS.md",
-          "sha256": "e9f295540d331a517edbf956a1549d24077943cccc7b54532e9a1f7255380d7f",
-          "bytes": 5921
+          "sha256": "990bc5292b02cd09d52abbadd2168eba6d8cc0b4bc2edba2611602e0ebd8d856",
+          "bytes": 6960
         },
         {
           "path": "engine/AGENTS.md",
@@ -942,8 +942,8 @@
     },
     {
       "path": "ADAPTERS.md",
-      "sha256": "e9f295540d331a517edbf956a1549d24077943cccc7b54532e9a1f7255380d7f",
-      "bytes": 5921
+      "sha256": "990bc5292b02cd09d52abbadd2168eba6d8cc0b4bc2edba2611602e0ebd8d856",
+      "bytes": 6960
     },
     {
       "path": "AGENTS.md",
@@ -1099,7 +1099,7 @@
     "product-ui": "## `product-ui`\n\n- **Canvas:** responsive viewports declared in the design lock; verify at least one narrow and\n  one wide target when both are in scope.\n- **Primitives:** semantic HTML and project-native components. Preserve framework conventions,\n  routes, state, and real content rather than replacing the application with a mock.\n- **States:** loading, empty, error, success, disabled, focus, and responsive navigation are part\n  of the artifact when the screen owns those behaviors.\n- **Export:** source code plus reproducible dev/build commands and screenshot paths.\n- **QA:** run project checks, render the real route, inspect target viewports and important states,\n  and record what could not be exercised.",
     "social-carousel": "## `social-carousel`\n\nUse `sequential-story` unless another grammar clearly owns the content. The installed Claude\n`carousel-build` skill is the canonical companion when available:\n\n1. StyleSeed reads or compiles the grammar and writes brand/type/motion/content rules to\n   `STYLESEED.md`.\n2. `carousel-build` reads that lock, then applies deterministic engineering constraints:\n   3:4 `1080×1440`, platform safe zones, crop behavior, 8px rhythm, type scale, gradient\n   banding prevention, available font weights, and reproducible PIL rendering.\n3. Copy and publishing skills may add their own contracts without altering visual authority.\n4. `/ss-score` checks sequence coherence and grammar fit; `/ss-verify` opens every exported\n   frame and checks crop, safe zone, typography, rhythm, false text, and continuity.\n\nRecommended lock additions:\n\n```markdown\n- Surface adapter: social-carousel\n- Artifact type: information-carousel\n- Canvas: 1080x1440\n- Sequence grammar: hook → why → evidence → action → reframe → CTA\n- Renderer: carousel-build\n- Safe zone contract: adapter:ADAPTERS.md#social-carousel-integration\n```\n\nDo not duplicate the renderer's rapidly changing platform measurements inside a visual grammar.\nThe adapter/companion owns them; StyleSeed owns the visual judgment applied within them.",
     "slide-deck": "## `slide-deck`\n\n- **Canvas:** use the presentation renderer's declared aspect ratio and safe area. Assume distance\n  viewing; body copy that works on a web page is usually too small or dense on a slide.\n- **Sequence:** one claim per slide, visible narrative progression, and deliberate alternation\n  between statement, evidence, comparison, and action.\n- **Assets:** use real charts, diagrams, screenshots, and cited imagery. Never use a text-heavy\n  card grid as a substitute for a presentation.\n- **Export:** editable deck plus rendered PDF or page images.\n- **QA:** render every slide, inspect overflow and contrast, and compare repeated masters,\n  alignment, folios, and speaker-facing information.",
-    "document-report": "## `document-report`\n\n- **Canvas:** paginated output with explicit paper size, margins, headers/footers, and print-safe\n  color. Reading measure and page breaks take priority over app-like chrome.\n- **Structure:** title and executive summary establish the decision; headings, figures, tables,\n  notes, and appendices expose evidence at the right depth.\n- **Assets:** captions and sources remain attached to figures and tables. Repeated components use\n  document styles rather than local formatting.\n- **Export:** editable source plus visually verified PDF.\n- **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,\n  accessibility structure, and cross-page consistency.",
+    "document-report": "## `document-report`\n\n- **Canvas:** paginated output with explicit paper size, margins, headers/footers, and print-safe\n  color. Reading measure and page breaks take priority over app-like chrome.\n- **Structure:** title and executive summary establish the decision; headings, figures, tables,\n  notes, and appendices expose evidence at the right depth.\n- **Assets:** captions and sources remain attached to figures and tables. Repeated components use\n  document styles rather than local formatting.\n- **Export:** editable source plus visually verified PDF.\n- **QA:** render every page and inspect widows/orphans, clipped tables, broken links, page numbers,\n  accessibility structure, and cross-page consistency.\n\nRecommended lock additions:\n\n```markdown\n- Surface adapter: document-report\n- Artifact type: research-report\n- Paper size: Letter\n- Margins: 0.75in top/bottom, 0.85in inner/outer\n- Header/footer: report title in header, section label optional, page number in footer\n- Reading measure: 60-75 characters for body text\n- Renderer: document/PDF renderer\n- Editable source: DOCX or structured source document\n- PDF export: required\n- Render evidence: page-by-page PDF images or screenshots\n- QA checks: widows/orphans, clipped tables, links, page numbers, accessibility structure\n- Physical output contract: renderer owns pagination, paper metrics, export fidelity, and PDF tags\n```\n\nFailing example:\n\n```markdown\n- Surface adapter: document-report\n- Layout assumption: reuse responsive web cards and let content scroll vertically\n```\n\nPaginated reports do not inherit web viewport assumptions. StyleSeed owns the report hierarchy,\nreading rhythm, and visual judgment; the renderer owns page boundaries, margins, flow, and export\nconstraints.",
     "single-frame": "## `single-frame`\n\n- **Canvas:** declare exact dimensions, crop variants, safe zones, and intended viewing distance.\n- **Composition:** one dominant message and one supporting action or proof. The frame must work\n  without surrounding caption text unless the publishing contract says otherwise.\n- **Assets:** logos, product imagery, and text are deterministic and legible. Generated imagery\n  must not supply final logos or critical text.\n- **Export:** source plus final PNG/JPEG/SVG variants and an asset manifest.\n- **QA:** inspect at native size and thumbnail size, verify crop variants, contrast, text safety,\n  and platform compression risk."
   },
   "domains": {


### PR DESCRIPTION
Closes #16.

Verified against the pinned tree: the patch applies cleanly and the repository's own build passes with it.
This repository ships no test suite, so **no test exercised this change**. Please treat CI as the first real check.

Written by an AI coding agent (Sloppy) and opened under my account.