### PR TITLE
Closes #15: Docs: add source-backed Korean mixed-script UI examples

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ implementation. Progress is tracked in the linked issues — comments and counte
   test does.
 - **Korean typography & UX-writing rules** — extend the canon beyond Latin-first assumptions:
   line-length and line-height rules for Hangul, mixed-script hierarchy, and Korean microcopy
-  patterns in `UX-WRITING.md`.
+  patterns in `UX-WRITING.md` (parent roadmap issue [#8](https://github.com/bitjaru/styleseed/issues/8)).
 
 ## Next
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ implementation. Progress is tracked in the linked issues — comments and counte
   test does.
 - **Korean typography & UX-writing rules** — extend the canon beyond Latin-first assumptions:
   line-length and line-height rules for Hangul, mixed-script hierarchy, and Korean microcopy
-  patterns in `UX-WRITING.md` (parent roadmap issue [#8](https://github.com/bitjaru/styleseed/issues/8)).
+  patterns in `UX-WRITING.md`.
 
 ## Next
 

--- a/demo-pricing/public/.well-known/styleseed/context-catalog.json
+++ b/demo-pricing/public/.well-known/styleseed/context-catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+  "engineRevision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
   "distributions": {
     "core": {
-      "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+      "revision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
       "files": [
         {
           "path": "LICENSE",
@@ -368,8 +368,8 @@
         },
         {
           "path": "engine/UX-WRITING.md",
-          "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
-          "bytes": 12263
+          "sha256": "bfbf7ed036b191f639d27bf459695f8162cee04bdff5da11e28ec30c7f0e53d2",
+          "bytes": 12524
         },
         {
           "path": "engine/VERSION",
@@ -1032,8 +1032,8 @@
     },
     {
       "path": "UX-WRITING.md",
-      "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
-      "bytes": 12263
+      "sha256": "bfbf7ed036b191f639d27bf459695f8162cee04bdff5da11e28ec30c7f0e53d2",
+      "bytes": 12524
     },
     {
       "path": "VERSION",

--- a/demo-pricing/public/.well-known/styleseed/context-catalog.json
+++ b/demo-pricing/public/.well-known/styleseed/context-catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
   "distributions": {
     "core": {
-      "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+      "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
       "files": [
         {
           "path": "LICENSE",
@@ -368,8 +368,8 @@
         },
         {
           "path": "engine/UX-WRITING.md",
-          "sha256": "8762afc773f31bfef606e2ddf7dcf5c68a648cfb087822f80b54bddfd063090c",
-          "bytes": 9830
+          "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
+          "bytes": 12263
         },
         {
           "path": "engine/VERSION",
@@ -1032,8 +1032,8 @@
     },
     {
       "path": "UX-WRITING.md",
-      "sha256": "8762afc773f31bfef606e2ddf7dcf5c68a648cfb087822f80b54bddfd063090c",
-      "bytes": 9830
+      "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
+      "bytes": 12263
     },
     {
       "path": "VERSION",

--- a/demo-pricing/public/.well-known/styleseed/registry.json
+++ b/demo-pricing/public/.well-known/styleseed/registry.json
@@ -20,7 +20,7 @@
   },
   "context": {
     "engineVersion": "4.1.0",
-    "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+    "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
     "resolverSkill": "https://raw.githubusercontent.com/bitjaru/styleseed/main/engine/.claude/skills/ss-resolve/SKILL.md",
     "catalogUrl": "https://styleseed-demo.vercel.app/.well-known/styleseed/context-catalog.json",
     "grammarIds": [

--- a/demo-pricing/public/.well-known/styleseed/registry.json
+++ b/demo-pricing/public/.well-known/styleseed/registry.json
@@ -20,7 +20,7 @@
   },
   "context": {
     "engineVersion": "4.1.0",
-    "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+    "engineRevision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
     "resolverSkill": "https://raw.githubusercontent.com/bitjaru/styleseed/main/engine/.claude/skills/ss-resolve/SKILL.md",
     "catalogUrl": "https://styleseed-demo.vercel.app/.well-known/styleseed/context-catalog.json",
     "grammarIds": [

--- a/demo-pricing/public/llms-full.txt
+++ b/demo-pricing/public/llms-full.txt
@@ -5676,10 +5676,11 @@ term, full product name, or policy wording even when a shorter UI phrase would s
 
 **Money or percentage + tabular numerals**
 - **Do:** `이번 달 12,400원 절약했어요` / `전월보다 8% 낮아요`
-- **Don't:** `이번 달에 절약한 금액은 십이만사천원입니다` / `전월 대비 8 퍼센트만큼 감소`
-- **Why:** Arabic numerals make changing values easier to compare and should render with tabular
-  numerals in UI. In Korean, currency symbols and common unit signs can sit tight with Arabic
-  numerals in compact UI (`12,400원`, `8%`), while the sentence explains the meaning in plain Korean.
+- **Don't:** `이번 달에 절약한 금액은 일만 이천사백 원입니다` / `전월 대비 8 퍼센트만큼 감소`
+- **Why:** Arabic numerals make changing values easier to compare. Use tabular numerals when
+  aligned or repeatedly updated UI values need stable digit widths. In Korean, currency symbols and
+  common unit signs can sit tight with Arabic numerals in compact UI (`12,400원`, `8%`), while the
+  sentence explains the meaning in plain Korean.
 
 **Number + unit in CTA or status**
 - **Do:** `3분 안에 끝내기` / `남은 공간 2GB`
@@ -5703,7 +5704,9 @@ Material Design & Apple HIG (writing) · Mailchimp Content Style Guide · Shopif
 [Toss Feed — UX Writing 인터뷰](https://toss.im/tossfeed/article/uxwriter-interview) (잡초 뽑기, TDS 버튼 규칙).
 StyleSeed restates Toss's published *principles*, not its proprietary copy.
 
-**§W9 mixed Korean UI strings:** [Toss App-in-Toss UX Writing](https://developers-apps-in-toss.toss.im/design/ux-writing.html)
-(해요체, active phrasing, positive/plain wording, and exceptions) ·
+**§W9 mixed Korean UI strings:** [Toss Tech — "토스의 8가지 라이팅 원칙들"](https://toss.tech/article/8-writing-principles-of-toss)
+(clear, concise, friendly, respectful, empathetic Korean UI wording) ·
 [국립국어원 온라인가나다 — 한글맞춤법 제43항 질문](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=27&pageIndex=1&qna_seq=326727)
-(unit nouns may attach to Arabic numerals under Hangul orthography rule 43).
+(unit nouns may attach to Arabic numerals under Hangul orthography rule 43) ·
+[W3C CSS Fonts Module Level 4 — `font-variant-numeric`](https://www.w3.org/TR/css-fonts-4/#font-variant-numeric-prop)
+(`tabular-nums` uses tabular figures for stable numeric alignment).

--- a/demo-pricing/public/llms-full.txt
+++ b/demo-pricing/public/llms-full.txt
@@ -5659,6 +5659,38 @@ above; for Korean UI, run them as the checklist:
 
 ---
 
+## §W9 — Korean mixed-script examples
+
+Use these when Hangul, Latin product or plan names, numerals, money, percentages, and units share
+one UI string. They apply to product UI, pricing, status, and CTA copy where the user needs to scan
+the value quickly. Counterexample: legal, billing, medical, or government copy may need the official
+term, full product name, or policy wording even when a shorter UI phrase would scan better.
+
+**Hangul + Latin product name**
+- **Do:** `Pro 플랜으로 업그레이드하기`
+- **Don't:** `프로 요금제 업그레이드 신청 제출`
+- **Why:** Keep the actual product or plan name if the user saw it that way elsewhere; translate the
+  surrounding action into natural Korean and make the CTA name the outcome. Toss's public writing
+  guide favors active, product-native 해요체 copy and action-specific buttons; that is useful evidence,
+  not a universal demand to copy Toss wording.
+
+**Money or percentage + tabular numerals**
+- **Do:** `이번 달 12,400원 절약했어요` / `전월보다 8% 낮아요`
+- **Don't:** `이번 달에 절약한 금액은 십이만사천원입니다` / `전월 대비 8 퍼센트만큼 감소`
+- **Why:** Arabic numerals make changing values easier to compare and should render with tabular
+  numerals in UI. In Korean, currency symbols and common unit signs can sit tight with Arabic
+  numerals in compact UI (`12,400원`, `8%`), while the sentence explains the meaning in plain Korean.
+
+**Number + unit in CTA or status**
+- **Do:** `3분 안에 끝내기` / `남은 공간 2GB`
+- **Don't:** `삼 분 이내 절차 진행` / `잔여 저장 공간: 2 기가바이트`
+- **Why:** Put the decision-making number where scanning starts, keep the unit users expect in the
+  product context, and avoid nominalized admin language. Use Korean units when they are the user's
+  mental model (`3분`); keep established technical units in Latin when that is how the product,
+  OS, or device labels them (`2GB`).
+
+---
+
 ## Sources
 
 **General UX writing:** Nielsen Norman Group (error messages, empty states, microcopy) ·
@@ -5670,3 +5702,8 @@ Material Design & Apple HIG (writing) · Mailchimp Content Style Guide · Shopif
 [Toss Tech — "토스 피플 #2: UX 라이팅의 새로운 기준"](https://toss.tech/article/toss-people-2) ·
 [Toss Feed — UX Writing 인터뷰](https://toss.im/tossfeed/article/uxwriter-interview) (잡초 뽑기, TDS 버튼 규칙).
 StyleSeed restates Toss's published *principles*, not its proprietary copy.
+
+**§W9 mixed Korean UI strings:** [Toss App-in-Toss UX Writing](https://developers-apps-in-toss.toss.im/design/ux-writing.html)
+(해요체, active phrasing, positive/plain wording, and exceptions) ·
+[국립국어원 온라인가나다 — 한글맞춤법 제43항 질문](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=27&pageIndex=1&qna_seq=326727)
+(unit nouns may attach to Arabic numerals under Hangul orthography rule 43).

--- a/demo-pricing/public/version.json
+++ b/demo-pricing/public/version.json
@@ -8,7 +8,7 @@
   "publicInstall": "npx skills add bitjaru/styleseed",
   "codexPackageStatus": "repository development Codex package",
   "version": "4.1.0",
-  "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+  "revision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
   "revisionFiles": 80,
   "skillsRevision": "sha256:4eab915c29fa928487d3f93bfcf7802fb887ab9f68202139cde7444db72578a1",
   "skillsRevisionFiles": 51,

--- a/demo-pricing/public/version.json
+++ b/demo-pricing/public/version.json
@@ -8,7 +8,7 @@
   "publicInstall": "npx skills add bitjaru/styleseed",
   "codexPackageStatus": "repository development Codex package",
   "version": "4.1.0",
-  "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
   "revisionFiles": 80,
   "skillsRevision": "sha256:4eab915c29fa928487d3f93bfcf7802fb887ab9f68202139cde7444db72578a1",
   "skillsRevisionFiles": 51,

--- a/engine/.claude/skills/ss-resolve/references/catalog.json
+++ b/engine/.claude/skills/ss-resolve/references/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+  "engineRevision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
   "distributions": {
     "core": {
-      "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+      "revision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
       "files": [
         {
           "path": "LICENSE",
@@ -368,8 +368,8 @@
         },
         {
           "path": "engine/UX-WRITING.md",
-          "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
-          "bytes": 12263
+          "sha256": "bfbf7ed036b191f639d27bf459695f8162cee04bdff5da11e28ec30c7f0e53d2",
+          "bytes": 12524
         },
         {
           "path": "engine/VERSION",
@@ -1032,8 +1032,8 @@
     },
     {
       "path": "UX-WRITING.md",
-      "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
-      "bytes": 12263
+      "sha256": "bfbf7ed036b191f639d27bf459695f8162cee04bdff5da11e28ec30c7f0e53d2",
+      "bytes": 12524
     },
     {
       "path": "VERSION",

--- a/engine/.claude/skills/ss-resolve/references/catalog.json
+++ b/engine/.claude/skills/ss-resolve/references/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
   "distributions": {
     "core": {
-      "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+      "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
       "files": [
         {
           "path": "LICENSE",
@@ -368,8 +368,8 @@
         },
         {
           "path": "engine/UX-WRITING.md",
-          "sha256": "8762afc773f31bfef606e2ddf7dcf5c68a648cfb087822f80b54bddfd063090c",
-          "bytes": 9830
+          "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
+          "bytes": 12263
         },
         {
           "path": "engine/VERSION",
@@ -1032,8 +1032,8 @@
     },
     {
       "path": "UX-WRITING.md",
-      "sha256": "8762afc773f31bfef606e2ddf7dcf5c68a648cfb087822f80b54bddfd063090c",
-      "bytes": 9830
+      "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
+      "bytes": 12263
     },
     {
       "path": "VERSION",

--- a/engine/UX-WRITING.md
+++ b/engine/UX-WRITING.md
@@ -192,10 +192,11 @@ term, full product name, or policy wording even when a shorter UI phrase would s
 
 **Money or percentage + tabular numerals**
 - **Do:** `이번 달 12,400원 절약했어요` / `전월보다 8% 낮아요`
-- **Don't:** `이번 달에 절약한 금액은 십이만사천원입니다` / `전월 대비 8 퍼센트만큼 감소`
-- **Why:** Arabic numerals make changing values easier to compare and should render with tabular
-  numerals in UI. In Korean, currency symbols and common unit signs can sit tight with Arabic
-  numerals in compact UI (`12,400원`, `8%`), while the sentence explains the meaning in plain Korean.
+- **Don't:** `이번 달에 절약한 금액은 일만 이천사백 원입니다` / `전월 대비 8 퍼센트만큼 감소`
+- **Why:** Arabic numerals make changing values easier to compare. Use tabular numerals when
+  aligned or repeatedly updated UI values need stable digit widths. In Korean, currency symbols and
+  common unit signs can sit tight with Arabic numerals in compact UI (`12,400원`, `8%`), while the
+  sentence explains the meaning in plain Korean.
 
 **Number + unit in CTA or status**
 - **Do:** `3분 안에 끝내기` / `남은 공간 2GB`
@@ -219,7 +220,9 @@ Material Design & Apple HIG (writing) · Mailchimp Content Style Guide · Shopif
 [Toss Feed — UX Writing 인터뷰](https://toss.im/tossfeed/article/uxwriter-interview) (잡초 뽑기, TDS 버튼 규칙).
 StyleSeed restates Toss's published *principles*, not its proprietary copy.
 
-**§W9 mixed Korean UI strings:** [Toss App-in-Toss UX Writing](https://developers-apps-in-toss.toss.im/design/ux-writing.html)
-(해요체, active phrasing, positive/plain wording, and exceptions) ·
+**§W9 mixed Korean UI strings:** [Toss Tech — "토스의 8가지 라이팅 원칙들"](https://toss.tech/article/8-writing-principles-of-toss)
+(clear, concise, friendly, respectful, empathetic Korean UI wording) ·
 [국립국어원 온라인가나다 — 한글맞춤법 제43항 질문](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=27&pageIndex=1&qna_seq=326727)
-(unit nouns may attach to Arabic numerals under Hangul orthography rule 43).
+(unit nouns may attach to Arabic numerals under Hangul orthography rule 43) ·
+[W3C CSS Fonts Module Level 4 — `font-variant-numeric`](https://www.w3.org/TR/css-fonts-4/#font-variant-numeric-prop)
+(`tabular-nums` uses tabular figures for stable numeric alignment).

--- a/engine/UX-WRITING.md
+++ b/engine/UX-WRITING.md
@@ -175,6 +175,38 @@ above; for Korean UI, run them as the checklist:
 
 ---
 
+## §W9 — Korean mixed-script examples
+
+Use these when Hangul, Latin product or plan names, numerals, money, percentages, and units share
+one UI string. They apply to product UI, pricing, status, and CTA copy where the user needs to scan
+the value quickly. Counterexample: legal, billing, medical, or government copy may need the official
+term, full product name, or policy wording even when a shorter UI phrase would scan better.
+
+**Hangul + Latin product name**
+- **Do:** `Pro 플랜으로 업그레이드하기`
+- **Don't:** `프로 요금제 업그레이드 신청 제출`
+- **Why:** Keep the actual product or plan name if the user saw it that way elsewhere; translate the
+  surrounding action into natural Korean and make the CTA name the outcome. Toss's public writing
+  guide favors active, product-native 해요체 copy and action-specific buttons; that is useful evidence,
+  not a universal demand to copy Toss wording.
+
+**Money or percentage + tabular numerals**
+- **Do:** `이번 달 12,400원 절약했어요` / `전월보다 8% 낮아요`
+- **Don't:** `이번 달에 절약한 금액은 십이만사천원입니다` / `전월 대비 8 퍼센트만큼 감소`
+- **Why:** Arabic numerals make changing values easier to compare and should render with tabular
+  numerals in UI. In Korean, currency symbols and common unit signs can sit tight with Arabic
+  numerals in compact UI (`12,400원`, `8%`), while the sentence explains the meaning in plain Korean.
+
+**Number + unit in CTA or status**
+- **Do:** `3분 안에 끝내기` / `남은 공간 2GB`
+- **Don't:** `삼 분 이내 절차 진행` / `잔여 저장 공간: 2 기가바이트`
+- **Why:** Put the decision-making number where scanning starts, keep the unit users expect in the
+  product context, and avoid nominalized admin language. Use Korean units when they are the user's
+  mental model (`3분`); keep established technical units in Latin when that is how the product,
+  OS, or device labels them (`2GB`).
+
+---
+
 ## Sources
 
 **General UX writing:** Nielsen Norman Group (error messages, empty states, microcopy) ·
@@ -186,3 +218,8 @@ Material Design & Apple HIG (writing) · Mailchimp Content Style Guide · Shopif
 [Toss Tech — "토스 피플 #2: UX 라이팅의 새로운 기준"](https://toss.tech/article/toss-people-2) ·
 [Toss Feed — UX Writing 인터뷰](https://toss.im/tossfeed/article/uxwriter-interview) (잡초 뽑기, TDS 버튼 규칙).
 StyleSeed restates Toss's published *principles*, not its proprietary copy.
+
+**§W9 mixed Korean UI strings:** [Toss App-in-Toss UX Writing](https://developers-apps-in-toss.toss.im/design/ux-writing.html)
+(해요체, active phrasing, positive/plain wording, and exceptions) ·
+[국립국어원 온라인가나다 — 한글맞춤법 제43항 질문](https://www.korean.go.kr/front/onlineQna/onlineQnaView.do?mn_id=27&pageIndex=1&qna_seq=326727)
+(unit nouns may attach to Arabic numerals under Hangul orthography rule 43).

--- a/extensions/learning/runtime/catalog.json
+++ b/extensions/learning/runtime/catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
   "grammars": {
     "commerce-conversion": true,
     "consumer-service": true,

--- a/extensions/learning/runtime/references/learning-catalog.json
+++ b/extensions/learning/runtime/references/learning-catalog.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "contractVersion": 2,
   "scannerVersion": 2,
-  "revision": "sha256:3e72cdd42ab24ccc0902b90289fa155f2724a5996e53d6de3e3497dcb52887a2",
+  "revision": "sha256:f546ab381049e5e3ec397b0119ec5f5b2e746aad750ffd8b4c51ab4589a601b2",
   "files": [
     {
       "path": "extensions/learning/runtime/catalog.json",
-      "sha256": "sha256:60824deaa87d5ff3c989d3670f52d26912b75da8c16eed1e6ef2ccf8bb252d4e"
+      "sha256": "sha256:5e56973e11d240c9c9192b0a1490824d60115876b22c4a0d26c324f433365f01"
     },
     {
       "path": "extensions/learning/skills/ss-learn/scripts/learning-contract.mjs",

--- a/skills/ss-resolve/references/catalog.json
+++ b/skills/ss-resolve/references/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+  "engineRevision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
   "distributions": {
     "core": {
-      "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
+      "revision": "sha256:3618e298e175c92f70d17998c9bdd284b41bc227a1bb46b76ed8c4baf4f5a113",
       "files": [
         {
           "path": "LICENSE",
@@ -368,8 +368,8 @@
         },
         {
           "path": "engine/UX-WRITING.md",
-          "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
-          "bytes": 12263
+          "sha256": "bfbf7ed036b191f639d27bf459695f8162cee04bdff5da11e28ec30c7f0e53d2",
+          "bytes": 12524
         },
         {
           "path": "engine/VERSION",
@@ -1032,8 +1032,8 @@
     },
     {
       "path": "UX-WRITING.md",
-      "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
-      "bytes": 12263
+      "sha256": "bfbf7ed036b191f639d27bf459695f8162cee04bdff5da11e28ec30c7f0e53d2",
+      "bytes": 12524
     },
     {
       "path": "VERSION",

--- a/skills/ss-resolve/references/catalog.json
+++ b/skills/ss-resolve/references/catalog.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 4,
   "engineVersion": "4.1.0",
-  "engineRevision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+  "engineRevision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
   "distributions": {
     "core": {
-      "revision": "sha256:f563a15b158ecef506f213c45ef54a71b34b4b1410c92529673b97ab34840772",
+      "revision": "sha256:20d50dd072e087f055807ce66845e47c7895d5b5a38188cdcc2b980820a99a91",
       "files": [
         {
           "path": "LICENSE",
@@ -368,8 +368,8 @@
         },
         {
           "path": "engine/UX-WRITING.md",
-          "sha256": "8762afc773f31bfef606e2ddf7dcf5c68a648cfb087822f80b54bddfd063090c",
-          "bytes": 9830
+          "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
+          "bytes": 12263
         },
         {
           "path": "engine/VERSION",
@@ -1032,8 +1032,8 @@
     },
     {
       "path": "UX-WRITING.md",
-      "sha256": "8762afc773f31bfef606e2ddf7dcf5c68a648cfb087822f80b54bddfd063090c",
-      "bytes": 9830
+      "sha256": "430954276b5f1515e742b22df6dc91daacb095753a0da6904e91f47f4b409b98",
+      "bytes": 12263
     },
     {
       "path": "VERSION",


### PR DESCRIPTION
Closes #15.

Verified against the pinned tree: the patch applies cleanly and the repository's own build passes with it.
This repository ships no test suite, so **no test exercised this change**. Please treat CI as the first real check.

Written by an AI coding agent (Sloppy) and opened under my account.