### PR TITLE
fix(web): degrade GitHub star failures gracefully

### DIFF
--- a/demo-pricing/app/api/github-stars/route.ts
+++ b/demo-pricing/app/api/github-stars/route.ts
@@ -1,33 +1,16 @@
 import { NextResponse } from "next/server";
 
-const REPOSITORY_API = "https://api.github.com/repos/bitjaru/styleseed";
+import { fetchGitHubStars } from "@/lib/github-stars.mjs";
 
 export const revalidate = 3600;
 
+const successCache = "public, s-maxage=3600, stale-while-revalidate=86400";
+const fallbackCache = "public, s-maxage=60, stale-while-revalidate=3600";
+
 export async function GET() {
-  try {
-    const response = await fetch(REPOSITORY_API, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "styleseed-demo",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-      next: { revalidate },
-    });
-
-    if (!response.ok) {
-      return NextResponse.json({ stars: null }, { status: 503 });
-    }
-
-    const repository = (await response.json()) as { stargazers_count?: unknown };
-    const stars =
-      typeof repository.stargazers_count === "number" ? repository.stargazers_count : null;
-
-    return NextResponse.json(
-      { stars },
-      { headers: { "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400" } },
-    );
-  } catch {
-    return NextResponse.json({ stars: null }, { status: 503 });
-  }
+  const stars = await fetchGitHubStars();
+  return NextResponse.json(
+    { stars },
+    { headers: { "Cache-Control": stars === null ? fallbackCache : successCache } },
+  );
 }

--- a/demo-pricing/lib/github-stars.mjs
+++ b/demo-pricing/lib/github-stars.mjs
@@ -1,0 +1,23 @@
+const REPOSITORY_API = "https://api.github.com/repos/bitjaru/styleseed";
+
+export const GITHUB_STARS_REVALIDATE_SECONDS = 3600;
+
+export async function fetchGitHubStars(fetchImplementation = globalThis.fetch) {
+  try {
+    const response = await fetchImplementation(REPOSITORY_API, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "styleseed-demo",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      next: { revalidate: GITHUB_STARS_REVALIDATE_SECONDS },
+    });
+
+    if (!response?.ok) return null;
+    const repository = await response.json();
+    const stars = repository?.stargazers_count;
+    return Number.isSafeInteger(stars) && stars >= 0 ? stars : null;
+  } catch {
+    return null;
+  }
+}

--- a/demo-pricing/scripts/test-browser-smoke.mjs
+++ b/demo-pricing/scripts/test-browser-smoke.mjs
@@ -164,6 +164,12 @@ try {
   await assertJson(baseUrl, "/.well-known/agent-skills/index.json", (value) => {
     assert(Array.isArray(value.skills) && value.skills.length === 23, "agent skill index does not expose 23 skills");
   });
+  await assertJson(baseUrl, "/api/github-stars", (value) => {
+    assert(
+      value.stars === null || (Number.isSafeInteger(value.stars) && value.stars >= 0),
+      "github stars endpoint returned an invalid fallback payload",
+    );
+  });
 
   browser = await chromium.launch({ headless: true });
   const failures = [

--- a/scripts/runtime-tests/github-stars.test.mjs
+++ b/scripts/runtime-tests/github-stars.test.mjs
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  fetchGitHubStars,
+  GITHUB_STARS_REVALIDATE_SECONDS,
+} from "../../demo-pricing/lib/github-stars.mjs";
+
+test("GitHub star loader returns a valid non-negative count", async () => {
+  let request;
+  const stars = await fetchGitHubStars(async (...args) => {
+    request = args;
+    return {
+      ok: true,
+      json: async () => ({ stargazers_count: 1234 }),
+    };
+  });
+
+  assert.equal(stars, 1234);
+  assert.equal(request[0], "https://api.github.com/repos/bitjaru/styleseed");
+  assert.equal(request[1].headers["User-Agent"], "styleseed-demo");
+  assert.equal(request[1].next.revalidate, GITHUB_STARS_REVALIDATE_SECONDS);
+});
+
+test("GitHub star loader degrades non-success responses to null", async () => {
+  const stars = await fetchGitHubStars(async () => ({ ok: false, status: 503 }));
+  assert.equal(stars, null);
+});
+
+test("GitHub star loader rejects malformed counts", async () => {
+  for (const stargazers_count of ["1234", -1, 1.5, Number.NaN, null]) {
+    const stars = await fetchGitHubStars(async () => ({
+      ok: true,
+      json: async () => ({ stargazers_count }),
+    }));
+    assert.equal(stars, null);
+  }
+});
+
+test("GitHub star loader degrades network and JSON failures to null", async () => {
+  assert.equal(await fetchGitHubStars(async () => { throw new Error("offline"); }), null);
+  assert.equal(await fetchGitHubStars(async () => ({
+    ok: true,
+    json: async () => { throw new Error("invalid JSON"); },
+  })), null);
+});


### PR DESCRIPTION
## Change

- treat the GitHub star count as non-critical display data and return `200 { "stars": null }` when the upstream API is unavailable or malformed
- cache degraded responses for 60 seconds instead of exposing an internal 503 to the homepage
- extract and unit-test the loader for non-2xx, malformed payload, JSON failure, and network failure paths
- include `/api/github-stars` in the production browser-smoke contract

## Related issue

Follow-up to the parallel-CI failure observed on Dependabot PR #26. No issue is closed.

## Evidence

```text
node scripts/verify-repo.mjs --webpack -> PASS; 68/68 runtime tests and 134-page production build
npm run test:browser (demo-pricing) -> PASS; 4 routes at desktop and 390x844 mobile/reduced-motion, plus public JSON endpoints
git diff --check -> PASS
```

The first local build attempt without network access failed only while fetching Google Fonts. The identical verifier passed with network access; this PR does not change fonts.

## Type

- [ ] Documentation, example, or translation
- [x] Regression fixture or bug fix
- [ ] Design rule or palette
- [ ] Skin, component, or pattern
- [ ] Grammar or adapter
- [ ] Agent skill or packaging
- [x] Other tooling

## Checklist

- [x] I changed the maintained source rather than only a generated mirror.
- [x] I ran the smallest relevant checks from `CONTRIBUTING.md`.
- [x] I reviewed every changed line, including AI-assisted output.
- [x] I attached current rendered evidence when pixels or interaction changed. (No intended pixel change; browser runtime evidence is listed above.)
- [x] I kept version, release, and deployment files unchanged unless explicitly requested.
