### PR TITLE
test: calibrate three-screen browser acceptance

### DIFF
--- a/.github/workflows/validate-engine.yml
+++ b/.github/workflows/validate-engine.yml
@@ -33,6 +33,16 @@ jobs:
       - name: Run browser smoke tests
         run: npm run test:browser
         working-directory: demo-pricing
+      - name: Calibrate three-screen browser acceptance
+        run: node scripts/test-design-pilot-browser.mjs --calibrate --output "${{ runner.temp }}/styleseed-pilot-browser"
+      - name: Preserve browser calibration evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: styleseed-pilot-browser-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/styleseed-pilot-browser
+          if-no-files-found: ignore
+          retention-days: 14
 
   windows-powershell:
     runs-on: windows-latest

--- a/demo-pricing/package-lock.json
+++ b/demo-pricing/package-lock.json
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -137,13 +137,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -159,20 +159,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -198,9 +198,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -360,13 +360,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -382,13 +382,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -404,13 +404,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -426,13 +426,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -448,13 +448,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -470,13 +470,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -492,13 +492,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -514,17 +514,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -534,16 +534,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -591,9 +591,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -2593,9 +2593,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
-      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -3326,9 +3326,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3343,31 +3343,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {

--- a/research/design-judgment/README.md
+++ b/research/design-judgment/README.md
@@ -55,7 +55,7 @@ Source reads use an explicit file list; skill copying follows the catalog invent
 scanning arbitrary extra files in an installation.
 
 The output has `arms/A` through `arms/D` plus `operator/`. Each arm has its own `PROMPT.md`,
-`TASK.md`, fixture tests, actual library, Next/React/Tailwind dependency declarations/lock, and CSS
+`TASK.md`, identical draft `BROWSER-CONTRACT.md`, fixture tests, actual library, Next/React/Tailwind dependency declarations/lock, and CSS
 entry point. Screen/layout/route implementations are deliberately absent, so this is not yet a
 buildable three-screen app. Demo lifecycle scripts are removed; no marketing-site code is copied.
 The full existing dependency graph is retained for reproducibility, not advertised as a minimal app.
@@ -84,6 +84,65 @@ API type correctness. They do not establish interactive UI behavior, rendering q
 accessibility, controlled agent exposure, or statistical validity. Example snippets are not running
 asynchronous state demonstrations. Do not present these checks as completed quality comparisons.
 
+## Browser acceptance and evaluator calibration
+
+The [draft browser protocol](common/BROWSER-CONTRACT.md) makes observable behavior testable without
+prescribing screen composition. All conditions receive it. The implementation under
+`scripts/design-pilot/` and the operator-only `operator/calibration/` DOM simulator are **never
+copied into A/B/C/D**. The simulator is deliberately not a React implementation or a design-system
+adoption example. It validates the evaluator, not a candidate app or expert design quality.
+
+After installing the locked demo dependencies and their Chromium binary:
+
+```sh
+npm ci --prefix demo-pricing
+cd demo-pricing
+npx playwright install chromium
+cd ..
+node scripts/test-design-pilot-browser.mjs --calibrate
+```
+
+Calibration runs 24 functional scenarios across desktop, mobile and mobile/reduced-motion
+contexts (70 applicable cases), plus 15 deliberate defects. It must pass **every** baseline case
+and reject every defect at its designated assertion. An environment/browser failure is not a
+successful defect detection. Missing cases, duplicate cases, missing screenshots, off-origin
+requests, console errors and input changes during the run cannot produce a passing result.
+Five additional boundary probes require protocol opt-in and block cross-origin fetch, redirect,
+WebSocket and popup attempts using two owned loopback servers. The receiving server must see
+zero requests. These are targeted browser controls, not an operating-system security sandbox.
+
+The scenarios exercise search/filter/selection, cancellation and atomic refusal, viewer
+restrictions, list/detail mutation consistency and history, error/loading/empty states,
+settings validation and failed-save recovery, saved-versus-draft navigation, visible keyboard
+focus, target-size/overflow checks and reduced-motion animation suppression. These checks do
+not establish full accessibility, pixel quality, React/component reuse or server authorization.
+The source of truth for the exact assertions is `scripts/design-pilot/scenarios.mjs`.
+
+For a separately launched **disposable local candidate** implementing the protocol:
+
+```sh
+node scripts/test-design-pilot-browser.mjs --url http://127.0.0.1:3210
+```
+
+The runner accepts only an explicit numeric loopback origin and requires protocol opt-in. It
+blocks off-origin browser requests, WebSockets, service workers and popups; it does not install,
+build or launch candidate code, load credentials, or operate a remote service. Use canonical routes
+that respond directly: HTTP redirects (including same-origin redirects) are refused. Supply only a
+credential-free synthetic test app, never a production session. A URL run is explicitly **not
+bound to candidate source** and cannot be attached as a StyleSeed acceptance report.
+
+Both modes create a fresh output directory outside the checkout; `--output <new-directory>` is
+optional and cannot overwrite an existing path. `report.json` records evaluator commit/dirty
+state, input hashes, Node/Playwright/Chromium versions, per-case controls, assertions and hashed
+screenshots. The full browser gate and Ubuntu CI run calibration. Windows runs the dependency-free
+runner contracts; Chromium calibration on Windows is not implied by that job.
+Ubuntu CI retains the synthetic report/screenshots as `styleseed-pilot-browser-<attempt>`
+artifacts for 14 days, including failed calibration runs when a report was produced.
+
+No run here changes the preparer's `readyForAgentRuns=false`, populates expert approval, executes
+a model comparison or promotes benchmark claims. Actual UI output review/blinding, source-bound
+candidate verification, expert rubric approval and the frozen generation runtime remain separate.
+
 ## Before any real model run
 
 1. Have named human experts approve the task/rubric, reference library, incompatibility handling,
@@ -93,9 +152,9 @@ asynchronous state demonstrations. Do not present these checks as completed qual
 3. Put each condition in a separate restricted environment. Sibling folders are **not a security
    boundary**: globally installed skills, parent instructions, network/repo access and session history
    can contaminate a comparison. Copy only one arm into the actual runtime and verify isolation.
-4. Implement/freeze browser acceptance checks for every task state, including selection reset,
-   cancel/confirm, routing recovery, saving/failed retry and dirty navigation. Pure model tests are
-   not substitutes. Run the shared-library compatibility rehearsal before paid generation.
+4. Review/freeze the draft browser acceptance checks against actual candidate implementations,
+   including the documented coverage limits and explicit protocol adapter. Calibration of the
+   evaluator is not a shared-library compatibility trial. Run that rehearsal before paid generation.
 5. Randomize and blind result labels for human review, record disagreements and actual rework/cost,
    then run the operator-only follow-up in a fresh session after initial outputs are frozen.
 

--- a/research/design-judgment/common/BROWSER-CONTRACT.md
+++ b/research/design-judgment/common/BROWSER-CONTRACT.md
@@ -1,0 +1,63 @@
+# Draft browser acceptance protocol v1
+
+This protocol is identical in A/B/C/D. It defines test access, not layout, visual style,
+expert approval, or a production API. The evaluator and its calibration fixtures remain
+operator-only. Passing it is not a design-quality score or complete accessibility audit.
+
+## Safe test boundary
+
+Run a disposable local app without credentials or production data. The browser runner accepts
+only an explicit `http://127.0.0.1:<port>` origin, blocks off-origin requests, WebSockets and
+service workers, and requires `<meta name="styleseed-pilot-protocol" content="1">` on each
+initial document. It does not start, build, install or execute candidate source code.
+HTTP redirects, including same-origin redirects, are refused: serve these canonical routes directly.
+Test state resets on a fresh browser context; list/detail/settings state survives in-app navigation.
+Do not implement evaluator-specific pass messages or inspect operator fixtures.
+
+## Test controls and selectors
+
+Support query parameters `role=editor|viewer` (default editor), and `fixture`:
+`loaded` (default), `list-loading`, `list-error`, `empty`, `detail-loading`, `detail-error`,
+`history-unavailable`, `save-failure`. These are explicit synthetic scenarios, not URL-based
+production permissions. A labelled `Save outcome` select with `success` / `failure` options
+in a separate fixture-control region changes the next save outcome without resetting the draft.
+Request-error retry restores loaded data. Loading fixtures stay pending until reconfigured.
+
+Use semantic HTML and accessible names. Exact hook names below make the same tests reusable;
+the surrounding copy and composition are not prescribed.
+
+- Named `Primary` navigation with links `Resources` and `Settings`.
+- On `/resources`: heading `Resources`, labelled `Search resources` input and `Status filter`
+  select (`all`, `active`, `paused`); labelled `Select all visible` checkbox; each resource row
+  has `data-resource-id="<id>"`, a checkbox `Select <resource name>`, a link named for the resource,
+  and `data-field="status"` containing `active` or `paused`.
+- Selected count uses `data-testid="selected-count"` containing just the integer. Buttons:
+  `Clear selection`, `Pause selected`. A modal dialog `Pause resources` lists affected names
+  and count, and has `Cancel` / `Confirm pause`. Success has a status announcement; refusals
+  have an alert with a reason. Cancellation preserves selection and records.
+- On detail routes: heading is the resource name; hooks `resource-status`, `resource-owner`,
+  `resource-protection`, `resource-history`; link `Back to resources` preserves list filters.
+  Unavailable history is explicitly different from empty history. Unknown IDs announce an alert.
+- On `/settings`: heading `Settings`; labels `Workspace name`, `Digest frequency`, `Retention days`;
+  `Save settings` button; `data-testid="unsaved"` shows `Unsaved changes` or `No unsaved changes`.
+  Invalid inputs set `aria-invalid="true"` and reference non-empty adjacent messages through
+  `aria-describedby`. Disable duplicate submits while saving; announce saving/success through
+  status and failure through alert. Viewer saves are disabled with a visible permission reason.
+- Dirty in-app navigation opens a modal `Discard changes?` with `Stay` / `Discard` buttons.
+  Stay retains draft and route; discard restores the last saved values, not the initial fixture.
+- Loading uses a visible status with `Loading`; request errors use an alert plus `Retry`.
+  Empty dataset uses `data-testid="empty-dataset"`; filtered no-results uses `no-results`.
+  Viewer restrictions use `data-testid="permission-reason"` and visible explanatory text.
+
+Control areas must stay keyboard-accessible at 1440×900 and 390×844, with visible focus and
+44px click/touch targets (a checkbox's label can provide the target). Required content must
+not cause document-wide horizontal overflow. Reduced-motion contexts must not run infinite or
+long (>500ms) animations. These mechanical checks do not measure all contrast, semantics or UX.
+
+## Explicit coverage limits
+
+The suite exercises observable browser behavior, not arbitrary unknown-ID mutation injection,
+server authorization, cross-tab persistence, a full screen-reader audit, React/library source
+reuse, pixel quality or expert judgment. Native reload/back/unload dirty-navigation behavior
+requires a separately approved policy; v1 checks the named in-app links only. The follow-up
+task stays held out. This protocol is a draft requiring expert approval before a quality trial.

--- a/research/design-judgment/operator/calibration/app.mjs
+++ b/research/design-judgment/operator/calibration/app.mjs
@@ -1,0 +1,179 @@
+// Operator-only DOM simulator for calibrating assertions. Never copied into candidate arms.
+import { filterResources, pauseResources, saveSettings, hasUnsavedChanges } from '/model.mjs';
+const initial = await (await fetch('/fixtures.json')).json();
+const { mutation } = JSON.parse(document.querySelector('#calibration-config').textContent);
+const params = new URLSearchParams(location.search);
+const role = params.get('role') || 'editor';
+let fixture = params.get('fixture') || 'loaded';
+let resources = structuredClone(initial.resources);
+const historyEvents = structuredClone(initial.history);
+let saved = structuredClone(initial.settings);
+let draft = structuredClone(saved);
+let query = '', status = 'all', selected = new Set(), notice = '', alert = '', saving = false;
+const main = document.querySelector('main');
+const outcome = document.querySelector('#save-outcome');
+outcome.value = fixture === 'save-failure' ? 'failure' : 'success';
+const escape = value => String(value).replace(/[&<>"']/gu, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[char]);
+const permission = () => role === 'viewer' ? '<p data-testid="permission-reason">Viewer role cannot change resources or save settings.</p>' : '';
+const messages = () => `<p role="status">${escape(notice)}</p>${alert ? `<p role="alert">${escape(alert)}</p>` : ''}`;
+const visibleResources = () => filterResources(fixture === 'empty' ? [] : resources, { query, status });
+
+function navigate(path, { force = false } = {}) {
+  if (!force && location.pathname === '/settings' && hasUnsavedChanges(saved, draft) && mutation !== 'dirty-navigation') {
+    dialog('Discard changes?', '<p>Your unsaved draft will be discarded.</p>', 'Stay', 'Discard', () => {
+      draft = structuredClone(saved); navigate(path, { force: true });
+    });
+    return;
+  }
+  if (mutation === 'filter-lost' && path === '/resources') { query = ''; status = 'all'; }
+  window.history.pushState({}, '', path);
+  notice = ''; alert = ''; render();
+}
+document.querySelector('nav').addEventListener('click', event => {
+  const link = event.target.closest('a');
+  if (link) { event.preventDefault(); navigate(link.getAttribute('href')); }
+});
+window.addEventListener('popstate', render);
+
+function dialog(name, body, cancel, confirm, action) {
+  const element = document.createElement('dialog');
+  element.setAttribute('aria-label', name);
+  element.innerHTML = `<h2>${escape(name)}</h2>${body}<button data-cancel>${cancel}</button><button data-confirm>${confirm}</button>`;
+  document.body.append(element);
+  const close = () => { element.close(); element.remove(); };
+  element.querySelector('[data-cancel]').onclick = () => {
+    if (mutation === 'ignore-cancel' && name === 'Pause resources') { close(); action(); } else close();
+  };
+  element.querySelector('[data-confirm]').onclick = () => { close(); action(); };
+  element.addEventListener('cancel', event => { event.preventDefault(); close(); });
+  element.showModal();
+}
+
+function pause() {
+  const effectiveRole = mutation === 'viewer-bulk' ? 'editor' : role;
+  let result = pauseResources(resources, [...selected], effectiveRole);
+  if (mutation === 'partial-update' && !result.ok) {
+    resources = resources.map(resource => selected.has(resource.id) && !resource.protected ? { ...resource, status: 'paused' } : resource);
+  }
+  if (result.ok) {
+    resources = result.resources;
+    for (const id of result.changedIds) historyEvents[id].push({ at: '2026-09-04T09:00:00Z', action: 'Resource paused', actor: 'Fixture editor' });
+    notice = `${result.changedIds.length} resources paused`; selected.clear(); alert = '';
+  } else { alert = result.reason; notice = ''; }
+  render();
+}
+
+function listRows() {
+  const rows = visibleResources();
+  const container = main.querySelector('#rows');
+  container.innerHTML = rows.map(resource => `<section data-resource-id="${resource.id}">
+    <label><input type="checkbox" aria-label="Select ${escape(resource.name)}" value="${resource.id}" ${selected.has(resource.id) ? 'checked' : ''}>Select</label>
+    <a href="/resources/${resource.id}">${escape(resource.name)}</a>
+    <span>${escape(resource.owner)}</span> <span data-field="status">${resource.status}</span>
+    ${resource.protected ? '<span>Protected</span>' : ''}
+  </section>`).join('');
+  if (rows.length === 0) container.innerHTML = fixture === 'empty'
+    ? '<p data-testid="empty-dataset">No resources yet.</p>' : '<p data-testid="no-results">No matching resources.</p>';
+  container.querySelectorAll('input').forEach(input => { input.onchange = () => {
+    if (input.checked) selected.add(input.value); else selected.delete(input.value);
+    updateSelection();
+  }; });
+  container.querySelectorAll('a').forEach(link => { link.onclick = event => { event.preventDefault(); navigate(link.getAttribute('href')); }; });
+  updateSelection();
+}
+
+function updateSelection() {
+  main.querySelector('[data-testid=selected-count]').textContent = selected.size;
+  const rows = visibleResources();
+  const all = main.querySelector('#select-all');
+  all.checked = rows.length > 0 && rows.every(resource => selected.has(resource.id));
+  all.indeterminate = !all.checked && rows.some(resource => selected.has(resource.id));
+  main.querySelector('#pause').disabled = !selected.size || (role === 'viewer' && mutation !== 'viewer-bulk');
+}
+
+function resourceList() {
+  main.innerHTML = '<h1>Resources</h1>';
+  if (fixture === 'list-loading') { main.innerHTML += '<p role="status">Loading resources</p>'; return; }
+  if (fixture === 'list-error') {
+    main.innerHTML += mutation === 'hidden-error' ? '<p>Nothing here.</p>' : '<p role="alert">Resources could not load.</p><button id="retry">Retry</button>';
+    const retry = main.querySelector('#retry');
+    if (retry) retry.onclick = () => { fixture = 'loaded'; render(); };
+    return;
+  }
+  main.innerHTML += `${permission()}${messages()}
+    <div class="controls"><label>Search resources <input id="search" value="${escape(query)}"></label>
+    <label for="filter">Status filter</label><select id="filter"><option value="all">All</option><option value="active">Active</option><option value="paused">Paused</option></select></div>
+    <label><input id="select-all" type="checkbox">Select all visible</label>
+    <span data-testid="selected-count">${selected.size}</span> selected
+    <button id="clear">Clear selection</button><button id="pause">Pause selected</button><div id="rows"></div>`;
+  main.querySelector('#filter').value = status;
+  main.querySelector('#search').oninput = event => { query = event.target.value; if (mutation !== 'selection-leak') selected.clear(); listRows(); };
+  main.querySelector('#filter').onchange = event => { status = event.target.value; if (mutation !== 'selection-leak') selected.clear(); listRows(); };
+  main.querySelector('#select-all').onchange = event => { selected = new Set(event.target.checked ? visibleResources().map(resource => resource.id) : []); listRows(); };
+  main.querySelector('#clear').onclick = () => { selected.clear(); listRows(); };
+  main.querySelector('#pause').onclick = () => dialog('Pause resources', `<p>${selected.size} selected</p><ul>${resources.filter(resource => selected.has(resource.id)).map(resource => `<li>${escape(resource.name)}</li>`).join('')}</ul>`, 'Cancel', 'Confirm pause', pause);
+  listRows();
+}
+
+function resourceDetail(id) {
+  const resource = (mutation === 'stale-detail' ? initial.resources : resources).find(item => item.id === id);
+  main.innerHTML = '<a id="back" href="/resources">Back to resources</a>';
+  main.querySelector('#back').onclick = event => { event.preventDefault(); navigate('/resources'); };
+  if (!resource) { main.innerHTML += '<h1>Unknown resource</h1><p role="alert">Resource not found.</p>'; return; }
+  main.innerHTML += `<h1>${escape(resource.name)}</h1>`;
+  if (fixture === 'detail-loading') { main.innerHTML += '<p role="status">Loading resource</p>'; return; }
+  if (fixture === 'detail-error') {
+    main.innerHTML += '<p role="alert">Resource could not load.</p><button id="retry">Retry</button>';
+    main.querySelector('#retry').onclick = () => { fixture = 'loaded'; render(); }; return;
+  }
+  main.innerHTML += `${permission()}<p data-testid="resource-status">${resource.status}</p><p data-testid="resource-owner">${escape(resource.owner)}</p>
+    <p data-testid="resource-protection">${resource.protected ? 'Protected' : 'Not protected'}</p>
+    <section data-testid="resource-history"><h2>History</h2>${fixture === 'history-unavailable'
+    ? '<p role="alert">History unavailable. Resource details remain available.</p>'
+    : historyEvents[id].length ? `<ol>${historyEvents[id].map(event => `<li>${escape(event.at)} — ${escape(event.action)} — ${escape(event.actor)}</li>`).join('')}</ol>` : '<p>No history yet.</p>'}</section>`;
+  // innerHTML additions replace the earlier anchor; wire it after the complete detail render.
+  main.querySelector('#back').onclick = event => { event.preventDefault(); navigate('/resources'); };
+}
+
+function settings(errors = {}) {
+  const field = (key, label, input) => `<label for="${key}">${label}</label>${input}<span id="${key}-error">${escape(errors[key] || '')}</span>`;
+  const attrs = key => `id="${key}" name="${key}" aria-invalid="${Boolean(errors[key])}" aria-describedby="${key}-error"`;
+  main.innerHTML = `<h1>Settings</h1>${permission()}${messages()}
+    <p data-testid="unsaved">${hasUnsavedChanges(saved, draft) ? 'Unsaved changes' : 'No unsaved changes'}</p>
+    <form novalidate>${field('workspaceName', 'Workspace name', `<input ${attrs('workspaceName')} value="${escape(draft.workspaceName)}">`)}
+    ${field('digest', 'Digest frequency', `<select ${attrs('digest')}><option value="daily">Daily</option><option value="weekly">Weekly</option><option value="off">Off</option></select>`)}
+    ${field('retentionDays', 'Retention days', `<input inputmode="numeric" ${attrs('retentionDays')} value="${escape(draft.retentionDays)}">`)}
+    <button type="submit" ${role === 'viewer' && mutation !== 'viewer-save' ? 'disabled' : ''}>Save settings</button></form>`;
+  main.querySelector('#digest').value = draft.digest;
+  if (mutation === 'missing-label') main.querySelector('label[for=workspaceName]').remove();
+  main.querySelectorAll('input,select').forEach(input => { input.oninput = input.onchange = () => {
+    draft[input.name] = input.value;
+    main.querySelector('[data-testid=unsaved]').textContent = hasUnsavedChanges(saved, draft) ? 'Unsaved changes' : 'No unsaved changes';
+  }; });
+  main.querySelector('form').onsubmit = event => {
+    event.preventDefault();
+    if (saving) return;
+    const actualDraft = mutation === 'invalid-save' ? saved : draft;
+    const result = saveSettings(saved, actualDraft, { role: mutation === 'viewer-save' ? 'editor' : role, fail: outcome.value === 'failure' });
+    if (result.reason === 'invalid') { notice = ''; alert = 'Correct the highlighted fields.'; settings(result.errors); return; }
+    saving = true;
+    main.querySelector('[role=status]').textContent = 'Saving settings';
+    if (mutation !== 'duplicate-save') main.querySelector('button[type=submit]').disabled = true;
+    main.querySelectorAll('input,select').forEach(input => { input.disabled = true; });
+    setTimeout(() => {
+      saving = false;
+      if (result.ok) { saved = result.saved; draft = structuredClone(saved); notice = 'Settings saved'; alert = ''; }
+      else { notice = ''; alert = result.reason; if (mutation === 'save-loss') draft = structuredClone(saved); }
+      settings();
+    }, 300);
+  };
+}
+
+function render() {
+  if (location.pathname === '/resources') resourceList();
+  else if (location.pathname === '/settings') settings();
+  else resourceDetail(location.pathname.split('/').at(-1));
+  if (mutation === 'overflow') main.style.width = '1800px';
+  if (mutation === 'motion') main.style.animation = 'calibration-motion 2s infinite linear';
+}
+render();

--- a/research/design-judgment/operator/calibration/index.html
+++ b/research/design-judgment/operator/calibration/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="styleseed-pilot-protocol" content="1">
+  <title>Browser evaluator calibration — not a product UI</title>
+  <style>
+    * { box-sizing: border-box; }
+    body { font: 16px/1.5 system-ui, sans-serif; margin: 16px auto; padding: 0 16px; max-width: 960px; }
+    a, button, input:not([type=checkbox]), select, label:has(input[type=checkbox]) { display: inline-flex; align-items: center; min-height: 44px; min-width: 44px; padding: 8px; font: inherit; }
+    label:has(input[type=checkbox]) { gap: 8px; }
+    input:not([type=checkbox]), select { max-width: 100%; }
+    :focus-visible { outline: 3px solid #174ea6; outline-offset: 2px; }
+    nav, .controls { display: flex; flex-wrap: wrap; gap: 8px; }
+    [data-resource-id], fieldset { margin: 12px 0; padding: 12px; border: 1px solid #777; min-width: 0; }
+    form label { display: block; }
+    dialog { max-width: calc(100% - 32px); }
+    [role=alert] { border-left: 4px solid #9c1717; padding-left: 12px; }
+    [hidden] { display: none !important; }
+    @keyframes calibration-motion { to { transform: translateX(6px); } }
+  </style>
+</head>
+<body>
+  <p>Operator-only browser test double. No expert approval or design-quality result.</p>
+  <nav aria-label="Primary"><a href="/resources">Resources</a><a href="/settings">Settings</a></nav>
+  <aside aria-label="Fixture controls"><label for="save-outcome">Save outcome</label><select id="save-outcome"><option value="success">Success</option><option value="failure">Failure</option></select></aside>
+  <main></main>
+  <script id="calibration-config" type="application/json">CALIBRATION_CONFIG</script>
+  <script type="module" src="/app.mjs"></script>
+</body>
+</html>

--- a/scripts/design-pilot/boundary-checks.mjs
+++ b/scripts/design-pilot/boundary-checks.mjs
@@ -1,0 +1,41 @@
+// Verify browser guard behavior with two owned loopback servers; never contact the Internet.
+import { createServer } from 'node:http';
+import { runAcceptance, viewports } from './browser.mjs';
+
+async function listen(handler) {
+  const server = createServer(handler);
+  await new Promise((done, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', done); });
+  return { server, origin: `http://127.0.0.1:${server.address().port}`, close: () => new Promise(done => { server.close(done); server.closeAllConnections(); }) };
+}
+
+export async function checkBrowserBoundaries(browser, output) {
+  let received = 0;
+  const sink = await listen((_, response) => { received++; response.end('unexpected request'); });
+  sink.server.on('upgrade', (_, socket) => { received++; socket.destroy(); });
+  const results = [];
+  try {
+    for (const kind of ['opt-in', 'off-origin', 'redirect', 'websocket', 'popup']) {
+      let actions = 0;
+      received = 0;
+      const app = await listen((request, response) => {
+        if (request.url === '/redirect') { response.writeHead(302, { Location: `${sink.origin}/probe` }).end(); return; }
+        if (request.url === '/favicon.ico') { response.writeHead(204).end(); return; }
+        response.setHeader('Content-Type', 'text/html');
+        const script = request.url === '/popup' ? '' : {
+          'opt-in': '', 'off-origin': `fetch('${sink.origin}/probe').catch(() => {});`,
+          redirect: "fetch('/redirect').catch(() => {});", websocket: `new WebSocket('${sink.origin.replace('http:', 'ws:')}/probe');`,
+          popup: "window.open('/popup');",
+        }[kind];
+        response.end(`<!doctype html><html><head>${kind === 'opt-in' ? '' : '<meta name="styleseed-pilot-protocol" content="1">'}</head><body><main><h1>Boundary fixture</h1></main><script>${script}</script></body></html>`);
+      });
+      try {
+        const run = await runAcceptance({ browser, baseUrl: app.origin, output, label: `boundary-${kind}`,
+          selectedScenarios: [{ id: kind, path: '/resources', run: async () => { actions++; } }], selectedViewports: [viewports[0]] });
+        const expected = { 'opt-in': 'Missing explicit', 'off-origin': 'Off-origin', redirect: 'Off-origin', websocket: 'WebSocket', popup: 'Unexpected popup' }[kind];
+        results.push({ id: kind, status: run.status === 'fail' && run.cases[0].environment.some(message => message.includes(expected))
+          && !run.cases[0].assertion && actions === 0 && received === 0 ? 'pass' : 'fail', actionsExecuted: actions, sinkRequests: received, evidence: run });
+      } finally { await app.close(); }
+    }
+  } finally { await sink.close(); }
+  return { status: results.every(result => result.status === 'pass') ? 'pass' : 'fail', results };
+}

--- a/scripts/design-pilot/browser.mjs
+++ b/scripts/design-pilot/browser.mjs
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { localOrigin, sha256 } from './support.mjs';
+import { scenarios } from './scenarios.mjs';
+
+export const viewports = Object.freeze([
+  { id: 'desktop', viewport: { width: 1440, height: 900 }, reducedMotion: 'no-preference' },
+  { id: 'mobile', viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true, reducedMotion: 'no-preference' },
+  { id: 'mobile-reduced', viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true, reducedMotion: 'reduce' },
+]);
+
+export async function runAcceptance({ browser, baseUrl, output, label, selectedScenarios = scenarios, selectedViewports = viewports }) {
+  baseUrl = localOrigin(baseUrl);
+  if (!/^[a-z0-9-]+$/u.test(label)) throw new Error('Unsafe evidence label');
+  if (!selectedScenarios.length || !selectedViewports.length) throw new Error('Cannot accept an empty browser suite');
+  const cases = [];
+  for (const viewport of selectedViewports) for (const scenario of selectedScenarios) {
+    if (scenario.reducedOnly && viewport.reducedMotion !== 'reduce') continue;
+    const { id: viewportId, ...options } = viewport;
+    const context = await browser.newContext({ ...options, serviceWorkers: 'block', acceptDownloads: false });
+    const environment = [];
+    const result = { id: scenario.id, viewport: viewportId, viewportSize: viewport.viewport, reducedMotion: viewport.reducedMotion,
+      controls: { role: 'editor', fixture: 'loaded', ...Object.fromEntries(new URL(scenario.path, baseUrl).searchParams) },
+      observedControls: null, status: 'fail', assertion: null, environment, screenshot: null };
+    let page;
+    try {
+      context.setDefaultTimeout(2000); context.setDefaultNavigationTimeout(10000);
+      await context.route('**/*', async route => {
+        try {
+          if (new URL(route.request().url()).origin !== baseUrl) {
+            environment.push('Off-origin request blocked'); await route.abort(); return;
+          }
+          // route.continue() can follow redirects without re-entering this handler. Inspect
+          // the response with redirects disabled; v1 deliberately refuses every redirect.
+          const response = await route.fetch({ maxRedirects: 0, timeout: 10000 });
+          const location = response.headers().location;
+          if (response.status() >= 300 && response.status() < 400 && location) {
+            const target = new URL(location, route.request().url());
+            environment.push(target.origin === baseUrl ? 'HTTP redirect blocked' : 'Off-origin redirect blocked');
+            await route.abort(); return;
+          }
+          await route.fulfill({ response });
+        } catch (error) { environment.push(`Request guard failed: ${error.message}`); await route.abort().catch(() => {}); }
+      });
+      await context.routeWebSocket('**/*', socket => { environment.push('WebSocket blocked'); socket.close(); });
+      page = await context.newPage();
+      context.on('page', popup => { environment.push('Unexpected popup'); void popup.close().catch(() => {}); });
+      page.on('pageerror', error => environment.push(`pageerror: ${error.message}`));
+      page.on('console', message => { if (message.type() === 'error') environment.push(`console.error: ${message.text()}`); });
+      page.on('response', response => {
+        if (response.status() >= 400 && !(scenario.id === 'detail-unknown' && response.status() === 404 && response.request().isNavigationRequest())) {
+          environment.push(`HTTP ${response.status()}: ${new URL(response.url()).pathname}`);
+        }
+      });
+      const response = await page.goto(`${baseUrl}${scenario.path}`, { waitUntil: 'networkidle' });
+      if (!response || (!response.ok() && !(scenario.id === 'detail-unknown' && response.status() === 404))) throw new Error('Test document did not load');
+      const optIn = page.locator('meta[name="styleseed-pilot-protocol"]');
+      if (await optIn.count() !== 1 || await optIn.getAttribute('content') !== '1') throw new Error('Missing explicit disposable-app protocol opt-in');
+      await page.locator('main h1').waitFor();
+      if (environment.length) throw new Error('Page environment failed before assertions');
+      try { await scenario.run(page); } catch (error) { result.assertion = error.message; }
+    } catch (error) { environment.push(error.message); }
+    finally {
+      if (page && !page.isClosed()) {
+        try {
+          const name = `${label}-${viewportId}-${scenario.id}.png`;
+          const path = join(output, name);
+          result.observedControls = await page.evaluate(() => ({
+            labelledValue: Object.fromEntries(['Save outcome', 'Search resources', 'Status filter'].map(name => {
+              const control = [...document.querySelectorAll('input,select')].find(element => element.getAttribute('aria-label') === name
+                || [...(element.labels || [])].some(label => label.textContent.trim() === name));
+              return [name, control?.value ?? null];
+            })),
+          }));
+          await page.screenshot({ path, fullPage: true, timeout: 10000 });
+          const bytes = readFileSync(path);
+          result.screenshot = { path: name, sha256: sha256(bytes), bytes: bytes.length, url: page.url() };
+        } catch (error) { environment.push(`Screenshot failed: ${error.message}`); }
+      }
+      await context.close();
+    }
+    result.status = !result.assertion && !environment.length && result.screenshot ? 'pass' : 'fail';
+    cases.push(result);
+    console.log(`${result.status.toUpperCase()} ${label}/${viewportId}/${scenario.id}`);
+    if (result.status === 'fail') console.log(`  ${result.assertion || environment.join('; ')}`);
+  }
+  if (!cases.length) throw new Error('No browser cases executed');
+  return { label, status: cases.every(result => result.status === 'pass') ? 'pass' : 'fail', cases };
+}

--- a/scripts/design-pilot/calibration-server.mjs
+++ b/scripts/design-pilot/calibration-server.mjs
@@ -1,0 +1,51 @@
+// Deliberately plain DOM test double. Not a React/library adoption or design-quality example.
+import { createServer } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const mutations = Object.freeze({
+  'selection-leak': 'list-selection',
+  'ignore-cancel': 'bulk-cancel',
+  'partial-update': 'bulk-atomic',
+  'viewer-bulk': 'viewer-bulk',
+  'stale-detail': 'bulk-shared-state',
+  'filter-lost': 'detail-context',
+  'save-loss': 'settings-retry',
+  'invalid-save': 'settings-validation',
+  'viewer-save': 'viewer-settings',
+  'dirty-navigation': 'settings-navigation',
+  'duplicate-save': 'settings-saving',
+  'hidden-error': 'list-retry',
+  'overflow': 'layout',
+  'motion': 'reduced-motion',
+  'missing-label': 'settings-labels',
+});
+
+export async function startCalibrationServer({ mutation = null } = {}) {
+  if (mutation !== null && !Object.hasOwn(mutations, mutation)) throw new Error('Unknown calibration mutation');
+  const resources = new Map([
+    ['/app.mjs', ['text/javascript', new URL('../../research/design-judgment/operator/calibration/app.mjs', import.meta.url)]],
+    ['/model.mjs', ['text/javascript', new URL('../../research/design-judgment/common/model.mjs', import.meta.url)]],
+    ['/fixtures.json', ['application/json', new URL('../../research/design-judgment/common/fixtures.json', import.meta.url)]],
+  ]);
+  const html = readFileSync(new URL('../../research/design-judgment/operator/calibration/index.html', import.meta.url), 'utf8')
+    .replace('CALIBRATION_CONFIG', JSON.stringify({ mutation }));
+  const payloads = new Map([...resources].map(([path, [type, url]]) => [path, { type, bytes: readFileSync(fileURLToPath(url)) }]));
+  const server = createServer((request, response) => {
+    if (request.method !== 'GET') { response.writeHead(405).end(); return; }
+    const path = new URL(request.url, 'http://127.0.0.1').pathname;
+    response.setHeader('Cache-Control', 'no-store');
+    const file = payloads.get(path);
+    if (file) { response.setHeader('Content-Type', file.type); response.end(file.bytes); return; }
+    if (path === '/favicon.ico') { response.writeHead(204).end(); return; }
+    if (path === '/resources' || path === '/settings' || /^\/resources\/[a-z0-9-]+$/u.test(path)) {
+      response.setHeader('Content-Type', 'text/html; charset=utf-8'); response.end(html); return;
+    }
+    response.writeHead(404).end('Not found');
+  });
+  await new Promise((done, reject) => { server.once('error', reject); server.listen(0, '127.0.0.1', done); });
+  return {
+    origin: `http://127.0.0.1:${server.address().port}`,
+    close: () => new Promise((done, reject) => { server.close(error => error ? reject(error) : done()); server.closeAllConnections(); }),
+  };
+}

--- a/scripts/design-pilot/scenarios.mjs
+++ b/scripts/design-pilot/scenarios.mjs
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+
+const text = async (locator, expected) => {
+  await locator.filter({ hasText: expected }).waitFor({ state: 'visible' });
+  const actual = (await locator.textContent()).trim();
+  if (typeof expected === 'string') assert.equal(actual, expected); else assert.match(actual, expected);
+};
+const row = (page, id) => page.locator(`[data-resource-id="${id}"]`);
+const fieldStatus = (page, id) => row(page, id).locator('[data-field=status]');
+const select = (page, name) => page.getByRole('checkbox', { name: `Select ${name}`, exact: true }).check();
+const pauseDialog = async page => {
+  await page.getByRole('button', { name: 'Pause selected', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Pause resources', exact: true });
+  await dialog.waitFor(); return dialog;
+};
+const confirm = async page => (await pauseDialog(page)).getByRole('button', { name: 'Confirm pause', exact: true }).click();
+const save = page => page.getByRole('button', { name: 'Save settings', exact: true }).click();
+const nameInput = page => page.getByLabel('Workspace name', { exact: true });
+const daysInput = page => page.getByLabel('Retention days', { exact: true });
+const nav = (page, name) => page.getByRole('navigation', { name: 'Primary', exact: true }).getByRole('link', { name, exact: true });
+const open = (page, name) => page.getByRole('link', { name, exact: true }).click();
+const isInvalid = async locator => {
+  assert.equal(await locator.getAttribute('aria-invalid'), 'true', 'Invalid input must be marked');
+  assert.equal(await locator.evaluate(input => (input.getAttribute('aria-describedby') || '').split(/\s+/u)
+    .some(id => document.getElementById(id)?.textContent.trim())), true, 'Input must reference a non-empty error message');
+};
+
+export const scenarios = [
+  { id: 'list-search', path: '/resources', run: async page => {
+    assert.equal(await page.locator('[data-resource-id]').count(), 4);
+    const search = page.getByLabel('Search resources', { exact: true });
+    await search.fill('  PLATFORM  ');
+    assert.equal(await page.locator('[data-resource-id]').count(), 2, 'Owner search trims and ignores case');
+    await page.getByLabel('Status filter', { exact: true }).selectOption('active');
+    assert.equal(await page.locator('[data-resource-id]').count(), 1);
+    await text(row(page, 'res-101'), /Payments API/u);
+    await search.fill('RES-102'); await text(row(page, 'res-102'), /Search index/u);
+    await search.fill('audit EXPORTER'); await text(row(page, 'res-104'), /Audit exporter/u);
+    await search.fill('not-present'); await text(page.getByTestId('no-results'), /.+/u);
+    assert.equal(await page.getByTestId('empty-dataset').count(), 0);
+  } },
+  { id: 'list-selection', path: '/resources', run: async page => {
+    await select(page, 'Search index'); await text(page.getByTestId('selected-count'), '1');
+    await page.getByLabel('Search resources', { exact: true }).fill('Security');
+    await text(page.getByTestId('selected-count'), '0');
+    await page.getByRole('checkbox', { name: 'Select all visible', exact: true }).check();
+    await text(page.getByTestId('selected-count'), '1');
+    assert.equal(await page.getByRole('checkbox', { name: 'Select Audit exporter', exact: true }).isChecked(), true);
+    await page.getByLabel('Status filter', { exact: true }).selectOption('paused');
+    await text(page.getByTestId('selected-count'), '0');
+    await page.getByLabel('Search resources', { exact: true }).fill('');
+    await page.getByLabel('Status filter', { exact: true }).selectOption('all');
+    await page.getByRole('checkbox', { name: 'Select all visible', exact: true }).check();
+    await text(page.getByTestId('selected-count'), '4');
+    await page.getByRole('button', { name: 'Clear selection', exact: true }).click();
+    await text(page.getByTestId('selected-count'), '0');
+  } },
+  { id: 'bulk-cancel', path: '/resources', run: async page => {
+    await select(page, 'Search index'); await select(page, 'Audit exporter');
+    const dialog = await pauseDialog(page);
+    await text(dialog, /Search index/u); await text(dialog, /Audit exporter/u); await text(dialog, /2/u);
+    await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+    await text(fieldStatus(page, 'res-102'), 'active'); await text(fieldStatus(page, 'res-104'), 'active');
+    await text(page.getByTestId('selected-count'), '2');
+    await pauseDialog(page); await page.keyboard.press('Escape');
+    assert.equal(await page.getByRole('dialog').count(), 0);
+    await text(page.getByTestId('selected-count'), '2');
+  } },
+  { id: 'bulk-atomic', path: '/resources', run: async page => {
+    await select(page, 'Payments API'); await select(page, 'Search index'); await confirm(page);
+    await text(page.getByRole('alert'), /protect/iu);
+    await text(fieldStatus(page, 'res-101'), 'active'); await text(fieldStatus(page, 'res-102'), 'active');
+    await page.getByRole('button', { name: 'Clear selection', exact: true }).click();
+    await select(page, 'Digest worker'); await select(page, 'Search index'); await confirm(page);
+    await text(page.getByRole('alert'), /active|paused/iu); await text(fieldStatus(page, 'res-102'), 'active');
+  } },
+  { id: 'viewer-bulk', path: '/resources?role=viewer', run: async page => {
+    await select(page, 'Search index');
+    assert.equal(await page.getByRole('button', { name: 'Pause selected', exact: true }).isDisabled(), true, 'Viewer cannot bulk pause');
+    await text(page.getByTestId('permission-reason'), /viewer|permission/iu);
+    await text(fieldStatus(page, 'res-102'), 'active');
+  } },
+  { id: 'bulk-shared-state', path: '/resources', run: async page => {
+    await select(page, 'Search index'); await confirm(page);
+    await text(fieldStatus(page, 'res-102'), 'paused'); await text(fieldStatus(page, 'res-104'), 'active');
+    await text(page.getByRole('status'), /paused/iu);
+    await open(page, 'Search index'); await text(page.getByTestId('resource-status'), 'paused');
+    const history = await page.getByTestId('resource-history').textContent();
+    assert.ok(history.indexOf('Resource activated') >= 0 && history.indexOf('Resource paused') > history.indexOf('Resource activated'), 'History preserves chronological mutation evidence');
+    await open(page, 'Back to resources'); await text(fieldStatus(page, 'res-102'), 'paused');
+  } },
+  { id: 'detail-context', path: '/resources', run: async page => {
+    await page.getByLabel('Search resources', { exact: true }).fill('Security');
+    await page.getByLabel('Status filter', { exact: true }).selectOption('active');
+    await open(page, 'Audit exporter'); await text(page.getByTestId('resource-history'), /No history/iu);
+    await open(page, 'Back to resources');
+    assert.equal(await page.getByLabel('Search resources', { exact: true }).inputValue(), 'Security');
+    assert.equal(await page.getByLabel('Status filter', { exact: true }).inputValue(), 'active');
+    assert.equal(await page.locator('[data-resource-id]').count(), 1);
+  } },
+  { id: 'detail-fields', path: '/resources/res-101?role=viewer', run: async page => {
+    await text(page.getByRole('heading', { name: 'Payments API', exact: true }), 'Payments API');
+    await text(page.getByTestId('resource-status'), 'active'); await text(page.getByTestId('resource-owner'), 'Platform');
+    await text(page.getByTestId('resource-protection'), /^Protected$/u);
+    await text(page.getByTestId('resource-history'), /Protection enabled/u);
+    await text(page.getByTestId('permission-reason'), /viewer|permission/iu);
+  } },
+  { id: 'detail-unknown', path: '/resources/res-unknown', run: async page => {
+    await text(page.getByRole('alert'), /not found|unknown/iu);
+    await open(page, 'Back to resources'); await text(row(page, 'res-102'), /Search index/u);
+  } },
+  { id: 'history-unavailable', path: '/resources/res-102?fixture=history-unavailable', run: async page => {
+    await text(page.getByTestId('resource-history'), /unavailable/iu); await text(page.getByTestId('resource-status'), 'active');
+  } },
+  ...['list', 'detail'].flatMap(kind => {
+    const path = kind === 'list' ? '/resources' : '/resources/res-102';
+    return [
+      { id: `${kind}-loading`, path: `${path}?fixture=${kind}-loading`, run: page => text(page.getByRole('status'), /loading/iu) },
+      { id: `${kind}-retry`, path: `${path}?fixture=${kind}-error`, run: async page => {
+        await text(page.getByRole('alert'), /.+/u);
+        await page.getByRole('button', { name: 'Retry', exact: true }).click();
+        if (kind === 'list') await text(row(page, 'res-102'), /Search index/u);
+        else await text(page.getByTestId('resource-status'), 'active');
+        assert.equal(await page.getByRole('alert').count(), 0, 'Retry clears the request error');
+      } },
+    ];
+  }),
+  { id: 'list-empty', path: '/resources?fixture=empty', run: async page => {
+    await text(page.getByTestId('empty-dataset'), /.+/u);
+    assert.equal(await page.locator('[data-resource-id]').count(), 0);
+    assert.equal(await page.getByTestId('no-results').count(), 0);
+  } },
+  { id: 'settings-labels', path: '/settings', run: async page => {
+    await nameInput(page).waitFor(); await daysInput(page).waitFor(); await page.getByLabel('Digest frequency', { exact: true }).waitFor();
+    assert.equal(await nameInput(page).evaluate(input => [...input.labels].some(label => label.textContent.trim().length > 0)), true, 'Visible input label is required');
+  } },
+  { id: 'settings-validation', path: '/settings', run: async page => {
+    for (const name of [' ', 'x', 'x'.repeat(41)]) {
+      await nameInput(page).fill(name); await save(page); await isInvalid(nameInput(page));
+      assert.equal(await nameInput(page).inputValue(), name, 'Validation retains invalid input');
+    }
+    await nameInput(page).fill('Valid workspace');
+    for (const days of ['', '6', '91', '7.5', '1e1']) {
+      await daysInput(page).fill(days); await save(page); await isInvalid(daysInput(page));
+      assert.equal(await daysInput(page).inputValue(), days);
+    }
+    await daysInput(page).fill('7'); await page.getByLabel('Digest frequency', { exact: true }).selectOption('off');
+    await save(page); await text(page.getByRole('status'), /saved/iu);
+    await text(page.getByTestId('unsaved'), 'No unsaved changes');
+    await daysInput(page).fill('90'); await save(page); await text(page.getByRole('status'), /saved/iu);
+  } },
+  { id: 'settings-retry', path: '/settings?fixture=save-failure', run: async page => {
+    await nameInput(page).fill('  Retained workspace  '); await daysInput(page).fill('45');
+    await page.getByLabel('Digest frequency', { exact: true }).selectOption('weekly'); await save(page);
+    await text(page.getByRole('alert'), /fail/iu);
+    assert.equal(await nameInput(page).inputValue(), '  Retained workspace  '); assert.equal(await daysInput(page).inputValue(), '45');
+    assert.equal(await page.getByLabel('Digest frequency', { exact: true }).inputValue(), 'weekly');
+    await text(page.getByTestId('unsaved'), 'Unsaved changes');
+    await page.getByLabel('Save outcome', { exact: true }).selectOption('success'); await save(page);
+    await text(page.getByRole('status'), /saved/iu); await text(page.getByTestId('unsaved'), 'No unsaved changes');
+    assert.equal(await nameInput(page).inputValue(), 'Retained workspace');
+    await nav(page, 'Resources').click(); await nav(page, 'Settings').click();
+    assert.equal(await nameInput(page).inputValue(), 'Retained workspace'); assert.equal(await daysInput(page).inputValue(), '45');
+  } },
+  { id: 'settings-saving', path: '/settings', run: async page => {
+    await nameInput(page).fill('Saving workspace'); await save(page); await text(page.getByRole('status'), /saving/iu);
+    assert.equal(await page.getByRole('button', { name: 'Save settings', exact: true }).isDisabled(), true, 'Pending save disables duplicate submission');
+    await text(page.getByRole('status'), /saved/iu);
+  } },
+  { id: 'viewer-settings', path: '/settings?role=viewer', run: async page => {
+    await nameInput(page).fill('Local viewer draft');
+    assert.equal(await page.getByRole('button', { name: 'Save settings', exact: true }).isDisabled(), true, 'Viewer cannot save');
+    await text(page.getByTestId('permission-reason'), /viewer|permission/iu);
+    await text(page.getByTestId('unsaved'), 'Unsaved changes');
+  } },
+  { id: 'settings-navigation', path: '/settings', run: async page => {
+    await nameInput(page).fill('Last saved workspace'); await save(page); await text(page.getByRole('status'), /saved/iu);
+    await nameInput(page).fill('Discard this draft'); await nav(page, 'Resources').click();
+    const dialog = page.getByRole('dialog', { name: 'Discard changes?', exact: true }); await dialog.waitFor();
+    await dialog.getByRole('button', { name: 'Stay', exact: true }).click();
+    assert.equal(new URL(page.url()).pathname, '/settings'); assert.equal(await nameInput(page).inputValue(), 'Discard this draft');
+    await nav(page, 'Resources').click(); await dialog.getByRole('button', { name: 'Discard', exact: true }).click();
+    assert.equal(new URL(page.url()).pathname, '/resources'); await nav(page, 'Settings').click();
+    assert.equal(await nameInput(page).inputValue(), 'Last saved workspace'); await text(page.getByTestId('unsaved'), 'No unsaved changes');
+  } },
+  { id: 'keyboard', path: '/resources', run: async page => {
+    await page.keyboard.press('Tab');
+    assert.equal(await page.evaluate(() => {
+      const element = document.activeElement;
+      if (!element || element === document.body) return false;
+      const style = getComputedStyle(element);
+      return element.matches(':focus-visible') && ((style.outlineStyle !== 'none' && parseFloat(style.outlineWidth) > 0) || style.boxShadow !== 'none');
+    }), true, 'Keyboard entry has visible focus');
+    await nav(page, 'Settings').focus(); await page.keyboard.press('Enter');
+    await text(page.getByRole('heading', { name: 'Settings', exact: true }), 'Settings');
+  } },
+  { id: 'layout', path: '/resources', run: async page => {
+    for (const path of ['/resources', '/resources/res-102', '/settings']) {
+      await page.goto(new URL(path, page.url()).href, { waitUntil: 'networkidle' });
+      await page.locator('main h1').waitFor();
+      const failures = await page.evaluate(() => {
+        const failed = [];
+        const width = document.documentElement.clientWidth;
+        if (document.documentElement.scrollWidth > width + 1 || document.body.scrollWidth > width + 1) failed.push('document overflow');
+        for (const node of document.querySelectorAll('a,button,input,select')) {
+          const target = node.matches('input[type=checkbox]') ? node.closest('label') || node : node;
+          const box = target.getBoundingClientRect();
+          if (!box.width || !box.height) continue;
+          if (box.width < 43.5 || box.height < 43.5) failed.push(`small target: ${node.getAttribute('aria-label') || node.textContent || node.id}`);
+        }
+        return failed;
+      });
+      assert.deepEqual(failures, [], `${path} has no document overflow or undersized targets`);
+    }
+  } },
+  { id: 'reduced-motion', path: '/resources', reducedOnly: true, run: async page => {
+    assert.equal(await page.evaluate(() => matchMedia('(prefers-reduced-motion: reduce)').matches), true);
+    for (const path of ['/resources', '/resources/res-102', '/settings']) {
+      await page.goto(new URL(path, page.url()).href, { waitUntil: 'networkidle' });
+      await page.locator('main h1').waitFor();
+      const animations = await page.evaluate(() => document.getAnimations().filter(animation => {
+        const timing = animation.effect?.getComputedTiming();
+        return animation.playState === 'running' && timing && (timing.iterations === Infinity || Number(timing.duration) > 500);
+      }).length);
+      assert.equal(animations, 0, 'Reduced motion must suppress long or infinite animation');
+    }
+  } },
+];

--- a/scripts/design-pilot/support.mjs
+++ b/scripts/design-pilot/support.mjs
@@ -1,0 +1,49 @@
+import { createHash } from 'node:crypto';
+import { lstatSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+export const sha256 = bytes => `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+export const within = (root, path) => {
+  const rel = relative(root, path);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
+};
+
+export function localOrigin(value) {
+  let url;
+  try { url = new URL(value); } catch { throw new Error('Expected an explicit local HTTP origin'); }
+  if (url.protocol !== 'http:' || url.hostname !== '127.0.0.1' || !url.port || url.username || url.password
+    || url.pathname !== '/' || url.search || url.hash || !/^http:\/\/127\.0\.0\.1:\d+\/?$/u.test(value)) {
+    throw new Error('Only http://127.0.0.1:<port> without credentials, path, query or fragment is allowed');
+  }
+  return url.origin;
+}
+
+export function freshOutput(repo, output) {
+  const proposed = output ? resolve(output) : null;
+  const parent = realpathSync(proposed ? dirname(proposed) : tmpdir());
+  const target = proposed ? join(parent, basename(proposed)) : parent;
+  if (within(realpathSync(repo), target)) throw new Error('Browser evidence must be outside the source checkout');
+  if (proposed) { mkdirSync(target, { mode: 0o700 }); return target; }
+  return mkdtempSync(join(parent, 'styleseed-pilot-browser-'));
+}
+
+export function writeReport(output, report) {
+  writeFileSync(join(output, 'report.json'), `${JSON.stringify(report, null, 2)}\n`, { flag: 'wx', mode: 0o600 });
+}
+
+export function sourceInventory(root, paths) {
+  return [...paths].sort().map(path => {
+    const absolute = resolve(root, path);
+    if (!within(root, absolute)) throw new Error('Source inventory escape');
+    let cursor = root;
+    for (const part of relative(root, absolute).split(sep)) {
+      cursor = join(cursor, part);
+      if (lstatSync(cursor).isSymbolicLink()) throw new Error(`Refusing source symlink: ${path}`);
+    }
+    const stat = lstatSync(absolute);
+    if (!stat.isFile() || stat.nlink !== 1) throw new Error(`Refusing unsafe source: ${path}`);
+    const bytes = readFileSync(absolute);
+    return { path, bytes: bytes.length, sha256: sha256(bytes) };
+  });
+}

--- a/scripts/prepare-design-pilot.mjs
+++ b/scripts/prepare-design-pilot.mjs
@@ -73,6 +73,7 @@ export function buildPilotPlan(root = repo) {
   }
   read('scripts/prepare-design-pilot.mjs');
   const common = { 'TASK.md': read(`${study}/common/TASK.md`), 'LICENSE': read('LICENSE') };
+  common['BROWSER-CONTRACT.md'] = read(`${study}/common/BROWSER-CONTRACT.md`);
   for (const name of ['fixtures.json', 'model.mjs', 'model.test.mjs']) common[`fixture/${name}`] = read(`${study}/common/${name}`);
   for (const name of ['button.tsx', 'input.tsx', 'label.tsx', 'table.tsx', 'badge.tsx', 'utils.ts']) {
     common[`src/ui/${name}`] = read(`engine/components/ui/${name}`);
@@ -127,7 +128,7 @@ export function buildPilotPlan(root = repo) {
   const arms = {};
   for (const id of ['A', 'B', 'C', 'D']) {
     const files = { ...common };
-    let prompt = 'Complete TASK.md using this workspace only. Do not inspect sibling conditions, operator materials, or previous results. Report unsupported requirements and verification limits.\n';
+    let prompt = 'Complete TASK.md and the draft BROWSER-CONTRACT.md using this workspace only. Do not inspect sibling conditions, operator materials, or previous results. Report unsupported requirements and verification limits.\n';
     if (id !== 'A') {
       Object.assign(files, skillFiles, registry);
       prompt += 'Use the installed StyleSeed skills and the artifact registry. Preserve the existing library/theme; provisional resolver settings do not approve replacing them.\n';

--- a/scripts/runtime-tests/design-pilot-browser.test.mjs
+++ b/scripts/runtime-tests/design-pilot-browser.test.mjs
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { parseOptions, summarizeCalibration, evaluatorSources } from '../test-design-pilot-browser.mjs';
+import { localOrigin, freshOutput, writeReport, sourceInventory } from '../design-pilot/support.mjs';
+import { mutations } from '../design-pilot/calibration-server.mjs';
+import { scenarios } from '../design-pilot/scenarios.mjs';
+import { viewports } from '../design-pilot/browser.mjs';
+import { buildPilotPlan } from '../prepare-design-pilot.mjs';
+
+const repo = fileURLToPath(new URL('../../', import.meta.url));
+const temporary = t => { const root = mkdtempSync(join(tmpdir(), 'styleseed-browser-contract-')); t.after(() => rmSync(root, { recursive: true, force: true })); return root; };
+const baseline = () => ({ status: 'pass', cases: viewports.flatMap(viewport => scenarios
+  .filter(scenario => !scenario.reducedOnly || viewport.reducedMotion === 'reduce')
+  .map(scenario => ({ id: scenario.id, viewport: viewport.id, status: 'pass', assertion: null, environment: [], screenshot: { path: 'fixture.png' } }))) });
+const killed = () => Object.entries(mutations).map(([label, id]) => ({ label, status: 'fail', cases: [{ id, status: 'fail', assertion: 'Known behavior rejected', environment: [], screenshot: { path: 'fixture.png' } }] }));
+
+test('browser target accepts only explicit numeric loopback origins, never credentials or remote aliases', () => {
+  assert.equal(localOrigin('http://127.0.0.1:3210/'), 'http://127.0.0.1:3210');
+  for (const target of ['https://example.com', 'http://localhost:3210', 'http://127.1:3210', 'http://2130706433:3210',
+    'http://127.0.0.1:3210/settings', 'http://127.0.0.1:3210?x=1', 'http://127.0.0.1:3210/#fragment',
+    'http://user:secret@127.0.0.1:3210', 'https://127.0.0.1:3210', 'http://127.0.0.1', 'file:///tmp/app', 'http://127.0.0.1:80']) {
+    assert.throws(() => localOrigin(target), /origin|Only/u, target);
+  }
+});
+
+test('browser CLI refuses conflicting, duplicate, paid-run, approval and incomplete options', () => {
+  assert.deepEqual(parseOptions([]), { mode: 'calibration' });
+  assert.equal(parseOptions(['--url', 'http://127.0.0.1:3210']).mode, 'candidate');
+  for (const args of [['--calibrate', '--url', 'http://127.0.0.1:3210'], ['--calibrate', '--calibrate'],
+    ['--output'], ['--run'], ['--approve'], ['--model', 'x'], ['--help', '--calibrate'], ['--url', 'https://example.com']]) assert.throws(() => parseOptions(args));
+});
+
+test('browser help and invalid CLI options perform no IO in the invocation directory', t => {
+  const root = temporary(t);
+  for (const [args, code] of [[['--help'], 0], [['--run'], 1], [['--url', 'https://example.com'], 1]]) {
+    const run = spawnSync(process.execPath, [join(repo, 'scripts/test-design-pilot-browser.mjs'), ...args], { cwd: root, encoding: 'utf8', timeout: 10000 });
+    assert.equal(run.status, code, run.stderr);
+    assert.deepEqual(readdirSync(root), []);
+  }
+});
+
+test('browser evidence directories and report files are exclusive and cannot overwrite user paths', t => {
+  const root = temporary(t);
+  const output = freshOutput(repo, join(root, 'evidence with spaces'));
+  writeReport(output, { status: 'fail' });
+  assert.throws(() => freshOutput(repo, output), /EEXIST/u);
+  assert.throws(() => writeReport(output, { status: 'pass' }), /EEXIST/u);
+  assert.equal(JSON.parse(readFileSync(join(output, 'report.json'))).status, 'fail');
+  assert.throws(() => freshOutput(repo, join(repo, 'must-not-create-browser-evidence')), /outside/u);
+  const link = join(root, 'linked-output'); symlinkSync(output, link, 'junction');
+  assert.throws(() => freshOutput(repo, link), /EEXIST/u);
+  const inside = join(root, 'repository'); mkdirSync(inside);
+  const parentLink = join(root, 'linked-parent'); symlinkSync(inside, parentLink, 'junction');
+  assert.throws(() => freshOutput(inside, join(parentLink, 'evidence')), /outside/u);
+});
+
+test('calibration requires every baseline case and every independently detected mutation', () => {
+  const passed = summarizeCalibration(baseline(), killed());
+  assert.equal(passed.status, 'pass'); assert.equal(passed.detectedMutations, Object.keys(mutations).length);
+  const missingCase = baseline(); missingCase.cases.pop();
+  assert.equal(summarizeCalibration(missingCase, killed()).status, 'fail');
+  assert.equal(summarizeCalibration(baseline(), killed().slice(1)).status, 'fail');
+  const duplicateCase = baseline(); duplicateCase.cases[0] = duplicateCase.cases[1];
+  assert.equal(summarizeCalibration(duplicateCase, killed()).status, 'fail');
+  assert.equal(summarizeCalibration(baseline(), [...killed(), killed()[0]]).status, 'fail');
+});
+
+test('crashes, missing screenshots, unrelated assertions and survived mutants cannot count as detection', () => {
+  for (const tamper of [
+    run => { run.cases[0].environment.push('Browser crashed'); },
+    run => { run.cases[0].screenshot = null; },
+    run => { run.cases[0].id = 'unrelated'; },
+    run => { run.cases[0].assertion = null; },
+    run => { run.status = run.cases[0].status = 'pass'; },
+  ]) {
+    const runs = killed(); tamper(runs[0]);
+    assert.equal(summarizeCalibration(baseline(), runs).status, 'fail');
+  }
+  const broken = baseline(); broken.cases[0].environment.push('Off-origin request blocked');
+  assert.equal(summarizeCalibration(broken, killed()).status, 'fail');
+});
+
+test('every deliberate browser defect targets one maintained scenario and IDs are unique', () => {
+  const ids = scenarios.map(item => item.id);
+  assert.equal(new Set(ids).size, ids.length);
+  assert.equal(new Set(viewports.map(item => item.id)).size, viewports.length);
+  for (const id of Object.values(mutations)) assert.ok(ids.includes(id), id);
+});
+
+test('all conditions receive identical protocol but no calibration source or evaluator implementation', () => {
+  const plan = buildPilotPlan();
+  for (const arm of Object.values(plan.arms)) {
+    assert.deepEqual(arm['BROWSER-CONTRACT.md'], plan.common['BROWSER-CONTRACT.md']);
+    assert.equal(Object.keys(arm).some(path => /calibration|scenarios\.mjs|test-design-pilot-browser|operator/u.test(path)), false);
+  }
+  assert.equal(plan.manifest.readyForAgentRuns, false);
+  assert.equal(plan.manifest.functionalUiVerification, 'NOT PERFORMED');
+});
+
+test('evaluator provenance includes real source bytes and refuses symlinked or escaped source', t => {
+  assert.equal(sourceInventory(repo, evaluatorSources).length, evaluatorSources.length);
+  const root = temporary(t);
+  writeFileSync(join(root, 'source.mjs'), '// test');
+  symlinkSync(join(root, 'source.mjs'), join(root, 'linked.mjs'));
+  assert.throws(() => sourceInventory(root, ['linked.mjs']), /symlink/u);
+  assert.throws(() => sourceInventory(root, ['../escape']), /escape/u);
+  assert.equal(sourceInventory(root, ['source.mjs'])[0].bytes, 7);
+});

--- a/scripts/test-design-pilot-browser.mjs
+++ b/scripts/test-design-pilot-browser.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Functional evaluator calibration only; never a benchmark or autonomous design-quality claim.
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { startCalibrationServer, mutations } from './design-pilot/calibration-server.mjs';
+import { runAcceptance, viewports } from './design-pilot/browser.mjs';
+import { checkBrowserBoundaries } from './design-pilot/boundary-checks.mjs';
+import { scenarios } from './design-pilot/scenarios.mjs';
+import { freshOutput, localOrigin, sha256, sourceInventory, writeReport } from './design-pilot/support.mjs';
+
+const repo = fileURLToPath(new URL('../', import.meta.url));
+export const evaluatorSources = Object.freeze([
+  'scripts/test-design-pilot-browser.mjs', 'scripts/design-pilot/browser.mjs', 'scripts/design-pilot/scenarios.mjs',
+  'scripts/design-pilot/support.mjs', 'scripts/design-pilot/calibration-server.mjs', 'scripts/design-pilot/boundary-checks.mjs',
+  'research/design-judgment/operator/calibration/index.html', 'research/design-judgment/operator/calibration/app.mjs',
+  'research/design-judgment/common/BROWSER-CONTRACT.md', 'research/design-judgment/common/TASK.md',
+  'research/design-judgment/common/model.mjs', 'research/design-judgment/common/fixtures.json', 'demo-pricing/package-lock.json',
+]);
+
+export function parseOptions(args) {
+  if (args.length === 1 && args[0] === '--help') return { help: true };
+  const options = { mode: 'calibration' };
+  const seen = new Set();
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (seen.has(arg)) throw new Error(`Duplicate option: ${arg}`);
+    seen.add(arg);
+    if (arg === '--calibrate') continue;
+    if (!['--url', '--output'].includes(arg) || !args[index + 1] || args[index + 1].startsWith('--')) throw new Error(`Unsupported or missing option: ${arg}`);
+    options[arg.slice(2)] = args[++index];
+  }
+  if (options.url) {
+    if (seen.has('--calibrate')) throw new Error('Choose calibration or candidate URL, not both');
+    options.url = localOrigin(options.url); options.mode = 'candidate';
+  }
+  return options;
+}
+
+export function summarizeCalibration(baseline, mutationRuns) {
+  const expected = viewports.flatMap(viewport => scenarios.filter(scenario => !scenario.reducedOnly || viewport.reducedMotion === 'reduce')
+    .map(scenario => `${viewport.id}/${scenario.id}`)).sort();
+  const actual = baseline.cases.map(result => `${result.viewport}/${result.id}`).sort();
+  const complete = JSON.stringify(expected) === JSON.stringify(actual);
+  const baselinePassed = complete && baseline.status === 'pass' && baseline.cases.every(result => result.status === 'pass' && !result.assertion && !result.environment.length && result.screenshot);
+  const required = Object.keys(mutations).sort();
+  const supplied = mutationRuns.map(run => run.label).sort();
+  const detections = required.map(name => {
+    const run = mutationRuns.find(item => item.label === name);
+    const result = run?.cases[0];
+    const detected = run?.status === 'fail' && run.cases.length === 1 && result.id === mutations[name]
+      && result.status === 'fail' && Boolean(result.assertion) && !result.environment.length && Boolean(result.screenshot);
+    return { mutation: name, scenario: mutations[name], detected: Boolean(detected) };
+  });
+  return {
+    status: baselinePassed && JSON.stringify(required) === JSON.stringify(supplied) && detections.every(item => item.detected) ? 'pass' : 'fail',
+    complete, expectedCases: expected.length, passedCases: baseline.cases.filter(item => item.status === 'pass').length,
+    requiredMutations: required.length, detectedMutations: detections.filter(item => item.detected).length, detections,
+  };
+}
+
+async function main(args) {
+  const options = parseOptions(args);
+  if (options.help) {
+    console.log('Usage: node scripts/test-design-pilot-browser.mjs [--calibrate | --url http://127.0.0.1:<port>] [--output <new-directory>]\nRuns real Chromium functional checks, or calibrates them on a DOM test double and intentional defects. Never runs models, installs packages, approves quality, or launches candidate code.');
+    return;
+  }
+  const require = createRequire(new URL('../demo-pricing/package.json', import.meta.url));
+  const locked = JSON.parse(readFileSync(new URL('../demo-pricing/package-lock.json', import.meta.url))).packages['node_modules/playwright'].version;
+  const installed = require('playwright/package.json').version;
+  if (installed !== locked) throw new Error(`Playwright dependency drift (${installed} != ${locked}); run npm ci --prefix demo-pricing first`);
+  const { chromium } = require('playwright');
+  const sources = sourceInventory(repo, evaluatorSources);
+  const git = args => {
+    const result = spawnSync('git', args, { cwd: repo, encoding: 'utf8', timeout: 10000 });
+    if (result.status !== 0) throw new Error('Cannot record evaluator source provenance');
+    return result.stdout.trim();
+  };
+  const output = freshOutput(repo, options.output);
+  const report = {
+    schemaVersion: 1, mode: options.mode, status: 'incomplete', sourceRevision: git(['rev-parse', 'HEAD']),
+    checkoutDirty: Boolean(git(['status', '--porcelain', '--untracked-files=all'])),
+    evaluatorHash: sha256(JSON.stringify(sources)), sourceInventory: sources,
+    versions: { node: process.version, playwright: installed, chromium: null },
+    runs: [], calibration: null, boundaries: null, errors: [], sourceBinding: options.mode === 'calibration' ? 'operator-test-double-only' : 'NOT BOUND TO CANDIDATE SOURCE',
+    agentRuns: 'NOT RUN', humanVisualReview: 'NOT PERFORMED', qualityImprovement: 'NOT ESTABLISHED', readyForAgentRuns: false,
+    limits: ['DOM simulator is not a React/library adoption trial.', 'Browser checks are not expert quality scores or a complete accessibility/security audit.',
+      'Candidate code is never launched or installed by this runner.', 'No source-bound StyleSeed gate acceptance or human approval is created.'],
+  };
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    report.versions.chromium = browser.version();
+    if (options.mode === 'candidate') {
+      const run = await runAcceptance({ browser, baseUrl: options.url, output, label: 'candidate' });
+      report.runs.push(run); report.status = run.status;
+    } else {
+      const server = await startCalibrationServer();
+      try { report.runs.push(await runAcceptance({ browser, baseUrl: server.origin, output, label: 'baseline' })); }
+      finally { await server.close(); }
+      for (const [mutation, scenarioId] of Object.entries(mutations)) {
+        const server = await startCalibrationServer({ mutation });
+        try {
+          report.runs.push(await runAcceptance({ browser, baseUrl: server.origin, output, label: mutation,
+            selectedScenarios: scenarios.filter(item => item.id === scenarioId),
+            selectedViewports: [viewports.find(item => item.id === (scenarioId === 'reduced-motion' ? 'mobile-reduced' : 'mobile'))] }));
+        } finally { await server.close(); }
+      }
+      report.calibration = summarizeCalibration(report.runs[0], report.runs.slice(1));
+      report.boundaries = await checkBrowserBoundaries(browser, output);
+      report.status = report.calibration.status === 'pass' && report.boundaries.status === 'pass' ? 'pass' : 'fail';
+    }
+  } catch (error) { report.errors.push(error.stack || error.message); report.status = 'fail'; }
+  finally {
+    if (browser) await browser.close();
+    try {
+      if (sha256(JSON.stringify(sourceInventory(repo, evaluatorSources))) !== report.evaluatorHash) {
+        report.errors.push('Evaluator inputs changed during the browser run; results cannot be frozen.');
+        report.status = 'fail';
+      }
+    } catch (error) { report.errors.push(error.message); report.status = 'fail'; }
+    writeReport(output, report);
+  }
+  console.log(JSON.stringify({ status: report.status, mode: report.mode, output, calibration: report.calibration, boundaries: report.boundaries?.status,
+    agentRuns: report.agentRuns, qualityImprovement: report.qualityImprovement }, null, 2));
+  if (report.status !== 'pass') process.exitCode = 1;
+}
+
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try { await main(process.argv.slice(2)); } catch (error) { console.error(error.stack || error.message); process.exitCode = 1; }
+}

--- a/scripts/verify-repo.mjs
+++ b/scripts/verify-repo.mjs
@@ -81,7 +81,10 @@ if (!flags.has("--core")) {
   run("Typecheck design-pilot API examples", node, ["scripts/check-design-pilot-examples.mjs"]);
   const buildArgs = flags.has("--webpack") ? ["run", "build", "--", "--webpack"] : ["run", "build"];
   run(flags.has("--webpack") ? "Build demo with Webpack" : "Build demo with Turbopack", npmCommand, buildArgs, demoRoot);
-  if (flags.has("--browser")) run("Run browser smoke tests", npmCommand, ["run", "test:browser"], demoRoot);
+  if (flags.has("--browser")) {
+    run("Run browser smoke tests", npmCommand, ["run", "test:browser"], demoRoot);
+    run("Calibrate design-pilot browser acceptance", node, ["scripts/test-design-pilot-browser.mjs", "--calibrate"]);
+  }
 }
 
 run("Check patch whitespace", "git", ["diff", "--check"]);


### PR DESCRIPTION
## Summary

Add the next bounded design-judgment verification layer: a reusable browser acceptance runner and calibrated assertions, not an agent-generated app or a quality benchmark.

- Share the same draft browser protocol across A/B/C/D without leaking evaluator code, operator calibration fixtures or held-out material into the candidate inputs.
- Exercise resource list, detail and settings across desktop, mobile and reduced-motion contexts: 24 scenarios / 70 applicable cases.
- Require every normal case to pass and 15 deliberate defects to fail at their designated assertions. Crashes, missing evidence or unrelated failures do not count as successful defect detection.
- Verify five safety boundaries against owned loopback servers: explicit protocol opt-in, off-origin fetch, redirects, WebSockets and popups. Reject all HTTP redirects before following them; the negative redirect probe exposed and now guards a real request-routing bypass.
- Preserve a new report and 90 hashed screenshots with source revision/dirty status, exact evaluator input hashes and actual Node/Playwright/Chromium versions. Refuse overwrite, unsafe destinations, unsupported arguments, empty/missing cases and source drift during a run.
- Integrate calibration into the full browser gate and Ubuntu CI; retain synthetic report/screenshots as CI artifacts for 14 days. Windows runs the dependency-free contracts, not Chromium calibration.

Stacked on #36 (`test/design-judgment-pilot`), with two separate commits:

1. `d5a6d9b`: patch existing vulnerable transitive dependencies inside Next.js's supported ranges: sharp 0.35.3 → 0.35.4 and baseline-browser-mapping 2.10.18 → 2.11.21. Preserve unrelated Linux libc metadata. [sharp advisory](https://github.com/advisories/GHSA-rgj7-g3m4-5g8c), [browser-mapping advisory](https://github.com/advisories/GHSA-w5vr-8v7q-w6rv).
2. `da8e9a3`: browser runner, protocol, calibration and CI evidence.

No engine-rule/version/public-positioning change, merge, production deployment or release.

## Verification

- PASS: focused pilot/runner unit tests: 20 cases; canonical core gate: 106 runtime tests.
- PASS: local `node scripts/verify-repo.mjs --webpack --browser`: 106 runtime tests; API examples and two invalid API uses; package/catalog/link checks; 134-page existing demo build; four-route desktop/mobile smoke; 70/70 positive browser cases, 15/15 defect detections and 5/5 boundary probes with zero receiving-server requests. This run was before committing the verified implementation.
- PASS: `npm ci --prefix demo-pricing` and npm audit: zero reported vulnerabilities after the targeted dependency patches.
- PASS: patched native sharp AVIF encode/decode round-trip; sharp 0.35.4 / libheif 1.23.2.
- PASS: clean committed A/B/C/D preparation at `da8e9a3af4cd27f9ca8bf042fe63437f4c6e714e`, `checkoutDirty=false`, input hash `sha256:3263c38c442a901a65f6ed9511315db6cf070fb508d0376997cb156a9c33bd6a`.
- PASS: `git diff --check`.
- PASS: clean committed calibration rerun at `da8e9a3af4cd27f9ca8bf042fe63437f4c6e714e`, `checkoutDirty=false`, evaluator hash `sha256:d7841cb2a5680d52c2a86d68c1e39b45e5240739393b23ee33356878c39c73db`: 70/70 baseline, 15/15 defect detections, 5/5 boundary probes. All 90 local screenshot hashes/byte counts were rechecked.
- PASS: candidate-URL CLI integration, 70 cases, using the **same operator DOM test double**. This is not an independent candidate or model run; its report correctly remains unbound to candidate source and establishes no quality improvement.
- PASS: [GitHub Actions run 34468408694](https://github.com/bitjaru/styleseed/actions/runs/34468408694) for PR head `da8e9a3`: raw logs show Ubuntu 106/106 runtime tests and full build/browser/calibration checks; Windows 106 tests / 105 pass / 0 fail / 1 explicit POSIX FIFO skip, plus 23-skill installation. Ubuntu npm audit also reports zero vulnerabilities.
- PASS: [CI evidence artifact](https://github.com/bitjaru/styleseed/actions/runs/34468408694/artifacts/10148581204) downloaded and independently checked: 90 screenshot hashes and byte counts match; every baseline/defect/boundary result revalidated. CI checks out synthetic PR merge commit `2f4c36197763eda632298098eb9f6291e902e6c9`; its exact evaluator source inventory/hash matches the clean local head. Runtime: Node 22.23.2, Playwright 1.62.1, Chromium 151.0.7922.34. Artifacts expire after 14 days.
- PASS: Vercel PR preview check. This is not a production deployment.

## Important limits

- The positive calibration implementation is deliberately a plain DOM test double, not React, not an expert-designed reference, and not proof of shared-library adoption or autonomous agent compliance.
- No A/B/C/D model run or real independent candidate has been executed. The successful 134-page build is the existing public demo, not the three-screen experiment starter.
- Candidate URL mode only operates on an explicitly opted-in, credential-free disposable loopback app. It does not install/build/launch candidate source. Its output is not source-bound StyleSeed gate evidence and cannot create approval.
- Protocol v1 checks named in-app dirty navigation, not native reload/back/unload behavior. It does not prove server authorization, all accessibility requirements, pixel quality, React/component reuse or expert judgment.
- `readyForAgentRuns` remains false. Expert task/rubric/library approval, actual candidate integration, runtime isolation, blinding, generation budgets and execution authorization remain separate.
- Optional official plugin validator binary remains unavailable; repository-native package/inventory checks pass.
