### PR TITLE
Test real React/CSS pilot integration and fix recipe inheritance

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Run disposable external application regression
         run: node scripts/test-external-app.mjs --output "${{ runner.temp }}/styleseed-release-external-app"
 
+      - name: Check pilot React and CSS integration
+        run: node scripts/test-design-pilot-library.mjs --output "${{ runner.temp }}/styleseed-release-pilot-library"
+
       - name: Calibrate three-screen browser acceptance
         run: node scripts/test-design-pilot-browser.mjs --calibrate --output "${{ runner.temp }}/styleseed-release-pilot-browser"
 
@@ -91,6 +94,8 @@ jobs:
           path: |
             ${{ runner.temp }}/styleseed-release-external-app/
             ${{ runner.temp }}/styleseed-release-pilot-browser/
+            ${{ runner.temp }}/styleseed-release-pilot-library/report.json
+            ${{ runner.temp }}/styleseed-release-pilot-library/*.png
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/validate-engine.yml
+++ b/.github/workflows/validate-engine.yml
@@ -43,6 +43,8 @@ jobs:
           path: ${{ runner.temp }}/styleseed-external-app-report/
           if-no-files-found: warn
           retention-days: 7
+      - name: Check pilot React and CSS integration
+        run: node scripts/test-design-pilot-library.mjs --output "${{ runner.temp }}/styleseed-pilot-library"
       - name: Calibrate three-screen browser acceptance
         run: node scripts/test-design-pilot-browser.mjs --calibrate --output "${{ runner.temp }}/styleseed-pilot-browser"
       - name: Preserve browser calibration evidence
@@ -50,7 +52,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: styleseed-pilot-browser-${{ github.run_attempt }}
-          path: ${{ runner.temp }}/styleseed-pilot-browser
+          path: |
+            ${{ runner.temp }}/styleseed-pilot-browser
+            ${{ runner.temp }}/styleseed-pilot-library/report.json
+            ${{ runner.temp }}/styleseed-pilot-library/*.png
           if-no-files-found: ignore
           retention-days: 14
 

--- a/research/design-judgment/README.md
+++ b/research/design-judgment/README.md
@@ -145,6 +145,39 @@ candidate verification, expert rubric approval and the frozen generation runtime
 
 ## Before any real model run
 
+### Shared-library integration check
+
+With the locked demo dependencies and Chromium installed, run:
+
+```sh
+node scripts/test-design-pilot-library.mjs
+```
+
+This operator-only probe compiles the actual copied React primitives, condition C API examples,
+and shared Tailwind/theme/recipe CSS. It checks nine assertions at desktop and 390×844: target
+size, recipe radius, brand-token wiring, containment, label/error relationships, controlled input,
+keyboard focus, busy-state click suppression/input retention, and table semantics. Three injected
+CSS defects must fail their designated assertions; missing cases/screenshots and browser errors
+cannot count as successful detection. The probe is not copied into any experimental arm.
+
+The first run found the example Input still used its vendor `rounded-md` (4px), while the selected
+recipe requires 3px. Its usage now explicitly adds `ss-pattern-control`; copied vendor/theme bytes
+remain unchanged. The report also records the unmodified vendor defaults, which still need
+usage-level adaptations and human compatibility review.
+
+Each run retains a fresh report, source/build hashes, dependency/browser versions and screenshots
+outside the checkout. `--output <new-directory>` cannot overwrite existing paths. It reuses locked
+checkout dependencies for compilation, with no install or network asset fetching. The temporary
+fixture's dependency link is not an isolated agent environment. CI uploads only the report/PNGs,
+not that link or the build workspace. Ubuntu CI and the full `--browser` gate run this probe;
+Windows runs its dependency-free runner contracts, not the Chromium probe.
+
+This verifies a bounded React/CSS integration slice, not the three-screen application, asynchronous
+backend behavior, complete accessibility, approved library compatibility, or design-quality gains.
+It does not change `readyForAgentRuns=false`, human approvals, budgets, or model-run counts.
+
+### Remaining human and execution prerequisites
+
 1. Have named human experts approve the task/rubric, reference library, incompatibility handling,
    noncompensable failures and promotion thresholds before outputs exist.
 2. Freeze exact model/runtime/tool versions, both code/input revisions, run count, time/token/spend
@@ -154,7 +187,8 @@ candidate verification, expert rubric approval and the frozen generation runtime
    can contaminate a comparison. Copy only one arm into the actual runtime and verify isolation.
 4. Review/freeze the draft browser acceptance checks against actual candidate implementations,
    including the documented coverage limits and explicit protocol adapter. Calibration of the
-   evaluator is not a shared-library compatibility trial. Run that rehearsal before paid generation.
+   evaluator is not a shared-library compatibility trial. The React/CSS probe above checks the
+   examples only; complete the three-screen candidate rehearsal before paid generation.
 5. Randomize and blind result labels for human review, record disagreements and actual rework/cost,
    then run the operator-only follow-up in a fresh session after initial outputs are frozen.
 

--- a/research/design-judgment/contexts/component-contract.md
+++ b/research/design-judgment/contexts/component-contract.md
@@ -25,6 +25,10 @@ this condition only makes relevant usage context explicit.
 - Follow the local `./utils` imports. No `@/components/ui/utils` alias is preconfigured here.
 - `Button` has sub-44px sizes and `Input` defaults to 36px height. Meet the common task's 44px
   floor through supported `className` overrides/wrappers; do not silently rewrite vendor files.
+- Apply `ss-pattern-control` to the Input usage when it must inherit the selected recipe's
+  control radius. `min-h-11` fixes the target height only: with this theme, the unmodified Input's
+  `rounded-md` computes to 4px while enterprise-workbench controls use 3px. The example makes that
+  usage-level override explicit without changing the copied component or theme.
 - Some Button variants contain fixed color values; Input has a fixed radius utility. Record
   conflicts with the requested system and use an applicable existing variant/override. These
   implementation limitations have not been endorsed by an expert or certified accessible.

--- a/research/design-judgment/contexts/examples.tsx
+++ b/research/design-judgment/contexts/examples.tsx
@@ -11,7 +11,7 @@ export function WorkspaceName({ value, error, onChange }: {
 }) {
   return <div>
     <Label htmlFor="workspace-name">Workspace name</Label>
-    <Input id="workspace-name" value={value} className="min-h-11"
+    <Input id="workspace-name" value={value} className="ss-pattern-control min-h-11"
       onChange={event => onChange(event.currentTarget.value)}
       aria-invalid={Boolean(error)} aria-describedby={error ? 'workspace-name-error' : undefined} />
     {error && <p id="workspace-name-error" role="alert">{error}</p>}

--- a/research/design-judgment/operator/library-probe.tsx
+++ b/research/design-judgment/operator/library-probe.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { WorkspaceName, SaveAction, ResourceRows } from '../context/examples';
+import { Button } from '../src/ui/button';
+import { Input } from '../src/ui/input';
+
+// Operator-only integration probe. Not a candidate screen, design reference or model answer.
+function Probe() {
+  const [value, setValue] = React.useState('Synthetic workspace');
+  const [error, setError] = React.useState<string | undefined>('Example validation error');
+  const [saving, setSaving] = React.useState(false);
+  const [saves, setSaves] = React.useState(0);
+  return <main data-styleseed-recipe="enterprise-workbench" style={{ padding: 16, maxWidth: 520 }}>
+    <h1>Operator-only component integration probe</h1>
+    <WorkspaceName value={value} error={error} onChange={next => { setValue(next); setError(undefined); }} />
+    <SaveAction saving={saving} onSave={() => { setSaving(true); setSaves(count => count + 1); }} />
+    <p role="status">Save calls: {saves}</p>
+    <button type="button" onClick={() => setSaving(false)}>Complete synthetic save</button>
+    <ResourceRows rows={[{ id: 'probe-1', name: 'Synthetic resource', status: 'Paused' }]} />
+    <h2>Unmodified vendor defaults — diagnostic only</h2>
+    <Input aria-label="Unmodified vendor input" data-testid="vendor-input" />
+    <Button data-testid="vendor-button">Unmodified vendor button</Button>
+  </main>;
+}
+
+createRoot(document.getElementById('root')!).render(<Probe />);

--- a/scripts/runtime-tests/design-pilot-library.test.mjs
+++ b/scripts/runtime-tests/design-pilot-library.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseOptions, summarize, mutations, requiredChecks, probeSources } from '../test-design-pilot-library.mjs';
+import { buildPilotPlan } from '../prepare-design-pilot.mjs';
+import { sourceInventory } from '../design-pilot/support.mjs';
+
+const repo = fileURLToPath(new URL('../../', import.meta.url));
+function runs() {
+  return ['desktop', 'mobile', ...Object.keys(mutations)].map(id => ({ id, executedChecks: [...requiredChecks],
+    failedChecks: mutations[id] ? [mutations[id]] : [], environment: [], screenshot: { path: `${id}.png` } }));
+}
+
+test('library probe accepts only a new output path; CLI help/refusals load no build dependencies or run code', t => {
+  assert.deepEqual(parseOptions([]), {});
+  assert.deepEqual(parseOptions(['--output', 'new folder']), { output: 'new folder' });
+  const root = mkdtempSync(join(tmpdir(), 'styleseed-library-cli-'));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  for (const [args, exit] of [[['--help'], 0], [['--run'], 1], [['--approve'], 1], [['--url', 'http://127.0.0.1:3000'], 1], [['--output'], 1]]) {
+    const result = spawnSync(process.execPath, [join(repo, 'scripts/test-design-pilot-library.mjs'), ...args], { cwd: root, encoding: 'utf8', timeout: 10000 });
+    assert.equal(result.status, exit, result.stderr);
+    assert.deepEqual(readdirSync(root), []);
+  }
+});
+
+test('library probe requires both real baselines and every designated defect, without environmental false positives', () => {
+  assert.equal(summarize(runs()).status, 'pass');
+  for (const tamper of [
+    result => result.pop(),
+    result => result.push(result[0]),
+    result => { result[0].failedChecks.push('recipe-radius'); },
+    result => { result[0].executedChecks.pop(); },
+    result => { result[2].failedChecks = []; },
+    result => { result[2].failedChecks = ['unrelated']; },
+    result => { result[2].failedChecks.push('unrelated'); },
+    result => { result[2].environment.push('browser crashed'); },
+    result => { result[2].screenshot = null; },
+  ]) { const result = runs(); tamper(result); assert.equal(summarize(result).status, 'fail'); }
+});
+
+test('probe remains operator-only; library bytes and experimental approval are not rewritten', () => {
+  const plan = buildPilotPlan();
+  for (const files of Object.values(plan.arms)) {
+    assert.equal(Object.keys(files).some(path => /library-probe|test-design-pilot-library|operator/u.test(path)), false);
+    assert.deepEqual(files['src/ui/input.tsx'], readFileSync(join(repo, 'engine/components/ui/input.tsx')));
+    assert.deepEqual(files['src/styles/theme.css'], readFileSync(join(repo, 'skins/stripe/theme.css')));
+  }
+  assert.equal(plan.manifest.readyForAgentRuns, false);
+  assert.equal(plan.manifest.humanVisualReview, 'NOT PERFORMED');
+  assert.match(plan.arms.C['context/examples.tsx'].toString(), /className="ss-pattern-control min-h-11"/u);
+  assert.equal(sourceInventory(repo, probeSources).length, probeSources.length);
+});

--- a/scripts/test-design-pilot-library.mjs
+++ b/scripts/test-design-pilot-library.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// Compile the actual shared library/C examples and exercise React in Chromium. No model runs.
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { buildPilotPlan } from './prepare-design-pilot.mjs';
+import { freshOutput, sha256, sourceInventory, writeReport } from './design-pilot/support.mjs';
+
+const repo = fileURLToPath(new URL('../', import.meta.url));
+export const probeSources = Object.freeze([
+  'scripts/test-design-pilot-library.mjs', 'scripts/design-pilot/support.mjs',
+  'research/design-judgment/operator/library-probe.tsx',
+]);
+export const mutations = Object.freeze({ 'missing-height-override': 'target-size', 'missing-recipe': 'recipe-radius', 'missing-theme': 'brand-token' });
+export const requiredChecks = Object.freeze(['target-size', 'recipe-radius', 'brand-token', 'responsive-containment',
+  'error-relationship', 'controlled-input', 'keyboard-focus', 'busy-state', 'table-semantics']);
+export function parseOptions(args) {
+  if (args.length === 1 && args[0] === '--help') return { help: true };
+  if (!args.length) return {};
+  if (args.length === 2 && args[0] === '--output' && args[1] && !args[1].startsWith('--')) return { output: args[1] };
+  throw new Error('Use --help or --output <new-directory>; no model, approval or candidate execution options exist');
+}
+
+export function summarize(runs) {
+  const expected = ['desktop', 'mobile', ...Object.keys(mutations)].sort();
+  const complete = JSON.stringify(runs.map(run => run.id).sort()) === JSON.stringify(expected);
+  const valid = run => run.environment.length === 0 && Boolean(run.screenshot)
+    && JSON.stringify([...run.executedChecks].sort()) === JSON.stringify([...requiredChecks].sort());
+  const baseline = runs.filter(run => ['desktop', 'mobile'].includes(run.id));
+  const detections = Object.entries(mutations).map(([id, check]) => {
+    const run = runs.find(item => item.id === id);
+    return { id, check, detected: Boolean(run && valid(run) && run.failedChecks.length === 1 && run.failedChecks[0] === check) };
+  });
+  return { status: complete && baseline.every(run => valid(run) && run.failedChecks.length === 0)
+    && detections.every(item => item.detected) ? 'pass' : 'fail', complete, detections };
+}
+
+async function build(root, plan, fromDemo) {
+  const save = (path, bytes) => { const target = join(root, path); mkdirSync(dirname(target), { recursive: true }); writeFileSync(target, bytes, { flag: 'wx' }); };
+  for (const [path, bytes] of Object.entries(plan.common)) if (path.startsWith('src/')) save(path, bytes);
+  save('context/examples.tsx', plan.arms.C['context/examples.tsx']);
+  save('operator/probe.tsx', readFileSync(join(repo, 'research/design-judgment/operator/library-probe.tsx')));
+  // Build-time dependency reuse only, never a claimed isolated agent environment.
+  symlinkSync(join(repo, 'demo-pricing/node_modules'), join(root, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir');
+  const ts = fromDemo('typescript');
+  const sources = [...Object.keys(plan.common).filter(path => /^src\/ui\/.*\.tsx?$/u.test(path)), 'context/examples.tsx', 'operator/probe.tsx'];
+  for (const path of sources) {
+    const result = ts.transpileModule(readFileSync(join(root, path), 'utf8'), { fileName: path, compilerOptions: {
+      jsx: ts.JsxEmit.ReactJSX, module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022,
+    } });
+    save(path.replace(/\.tsx?$/u, '.js'), result.outputText);
+  }
+  const { webpack } = fromDemo('next/dist/compiled/webpack/webpack');
+  await new Promise((done, reject) => {
+    const compiler = webpack({ mode: 'production', context: root, entry: './operator/probe.js',
+      output: { path: join(root, 'build'), filename: 'probe.js' }, devtool: false,
+      resolve: { extensions: ['.js'], modules: [join(repo, 'demo-pricing/node_modules')] },
+      optimization: { minimize: false }, cache: false,
+    });
+    compiler.run((error, stats) => compiler.close(closeError => {
+      if (error || closeError || stats?.hasErrors()) reject(error || closeError || new Error(stats.toString({ all: false, errors: true })));
+      else done();
+    }));
+  });
+  const postcss = fromDemo('postcss');
+  const tailwind = fromDemo('@tailwindcss/postcss');
+  const cssPath = join(root, 'src/app/globals.css');
+  // Scan the actual common library plus C examples; the probe adds no component utility overrides.
+  const css = await postcss([tailwind({ base: root })]).process(readFileSync(cssPath, 'utf8'), { from: cssPath });
+  save('build/probe.css', css.css);
+  return { javascript: readFileSync(join(root, 'build/probe.js')), css: css.css };
+}
+
+async function exercise(browser, origin, output, id) {
+  const context = await browser.newContext({ viewport: { width: id === 'desktop' ? 1440 : 390, height: id === 'desktop' ? 900 : 844 }, serviceWorkers: 'block' });
+  const result = { id, executedChecks: [], failedChecks: [], environment: [], measurements: null, screenshot: null };
+  const page = await context.newPage();
+  await context.route('**/*', route => {
+    if (new URL(route.request().url()).origin === origin) return route.continue();
+    result.environment.push('Off-origin request blocked'); return route.abort();
+  });
+  await context.routeWebSocket('**/*', socket => { result.environment.push('WebSocket blocked'); socket.close(); });
+  page.on('popup', popup => { result.environment.push('Unexpected popup'); void popup.close(); });
+  page.on('pageerror', error => result.environment.push(error.message));
+  page.on('console', message => { if (message.type() === 'error') result.environment.push(message.text()); });
+  page.on('response', response => { if (response.status() >= 400) result.environment.push(`HTTP ${response.status()}`); });
+  const check = async (name, fn) => { result.executedChecks.push(name); try { await fn(); } catch (error) { result.failedChecks.push(name); result[name] = error.message; } };
+  try {
+    const response = await page.goto(`${origin}/?case=${id}`, { waitUntil: 'networkidle', timeout: 15000 });
+    assert.equal(response.status(), 200);
+    const input = page.getByRole('textbox', { name: 'Workspace name', exact: true });
+    const button = page.getByRole('button', { name: 'Save settings', exact: true });
+    await input.waitFor({ state: 'visible' });
+    result.measurements = await page.evaluate(() => {
+      const input = document.querySelector('#workspace-name');
+      const button = [...document.querySelectorAll('button')].find(node => node.textContent === 'Save settings');
+      const metrics = node => { const style = getComputedStyle(node); const rect = node.getBoundingClientRect();
+        return { width: rect.width, height: rect.height, radius: style.borderTopLeftRadius, background: style.backgroundColor }; };
+      const brand = document.createElement('span'); brand.style.background = 'var(--brand)'; document.body.append(brand);
+      const brandColor = getComputedStyle(brand).backgroundColor; brand.remove();
+      return { input: metrics(input), button: metrics(button), brandColor,
+        vendorInput: metrics(document.querySelector('[data-testid="vendor-input"]')),
+        vendorButton: metrics(document.querySelector('[data-testid="vendor-button"]')),
+        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth + 1 };
+    });
+    await check('target-size', () => { for (const item of [result.measurements.input, result.measurements.button]) assert.ok(item.height >= 44 && item.width >= 44); });
+    await check('recipe-radius', () => { assert.equal(result.measurements.button.radius, '3px'); assert.equal(result.measurements.input.radius, '3px'); });
+    await check('brand-token', () => { assert.equal(result.measurements.button.background, result.measurements.brandColor); assert.equal(result.measurements.brandColor, 'rgb(83, 58, 253)'); });
+    await check('responsive-containment', () => assert.equal(result.measurements.overflow, false));
+    await check('error-relationship', async () => { assert.equal(await input.getAttribute('aria-invalid'), 'true'); assert.equal(await input.getAttribute('aria-describedby'), 'workspace-name-error'); assert.equal(await page.getByRole('alert').innerText(), 'Example validation error'); });
+    await check('controlled-input', async () => { await input.fill('Retained workspace'); assert.equal(await input.inputValue(), 'Retained workspace'); assert.equal(await input.getAttribute('aria-invalid'), 'false'); });
+    await check('keyboard-focus', async () => { await input.focus(); await page.keyboard.press('Tab'); assert.equal(await button.evaluate(node => node === document.activeElement && node.matches(':focus-visible') && getComputedStyle(node).boxShadow !== 'none'), true); });
+    await check('busy-state', async () => {
+      await button.click(); const busy = page.getByRole('button', { name: 'Saving…', exact: true });
+      assert.equal(await busy.isDisabled(), true); assert.equal(await busy.getAttribute('aria-busy'), 'true');
+      await busy.evaluate(node => node.click()); assert.equal(await page.getByRole('status').innerText(), 'Save calls: 1');
+      await page.getByRole('button', { name: 'Complete synthetic save' }).click(); await button.waitFor();
+      assert.equal(await input.inputValue(), 'Retained workspace'); assert.equal(await button.isEnabled(), true);
+    });
+    await check('table-semantics', async () => { assert.equal(await page.getByRole('table', { name: 'Resource status' }).count(), 1); assert.equal(await page.getByRole('columnheader').count(), 2); assert.equal(await page.getByText('Paused', { exact: true }).count(), 1); });
+    const path = `${id}.png`; await page.screenshot({ path: join(output, path), fullPage: true });
+    result.screenshot = { path, sha256: sha256(readFileSync(join(output, path))) };
+  } catch (error) { result.environment.push(error.message); }
+  finally { await context.close(); }
+  return result;
+}
+
+async function main(args) {
+  const options = parseOptions(args);
+  if (options.help) { console.log('Usage: node scripts/test-design-pilot-library.mjs [--output <new-directory>]\nOperator-only React/CSS compatibility probe. Requires installed locked demo dependencies and Chromium. No installs, candidate apps, model runs or approvals.'); return; }
+  const fromDemo = createRequire(join(repo, 'demo-pricing/package.json'));
+  const lock = JSON.parse(readFileSync(join(repo, 'demo-pricing/package-lock.json')));
+  const versions = {};
+  for (const name of ['react', 'react-dom', 'next', 'typescript', 'tailwindcss', '@tailwindcss/postcss', 'postcss', 'playwright', '@radix-ui/react-slot', '@radix-ui/react-label', 'class-variance-authority', 'clsx', 'tailwind-merge']) {
+    const actual = JSON.parse(readFileSync(join(repo, 'demo-pricing/node_modules', name, 'package.json'))).version;
+    assert.equal(actual, lock.packages[`node_modules/${name}`]?.version, `Dependency drift: ${name}`); versions[name] = actual;
+  }
+  const plan = buildPilotPlan(); const sources = sourceInventory(repo, probeSources);
+  const output = freshOutput(repo, options.output); const root = join(output, 'fixture'); mkdirSync(root);
+  const report = { schemaVersion: 1, status: 'incomplete', sourceRevision: plan.manifest.sourceRevision,
+    checkoutDirty: plan.manifest.checkoutDirty, inputHash: plan.manifest.inputHash, sourceInventory: plan.manifest.sourceInventory,
+    probeInventory: sources, versions: { node: process.version, ...versions }, runs: [], calibration: null, errors: [],
+    scope: 'operator-only React examples and shared CSS; not the three-screen candidate evaluator',
+    compatibilityApproval: 'NOT PERFORMED', agentRuns: 'NOT RUN', humanVisualReview: 'NOT PERFORMED', qualityImprovement: 'NOT ESTABLISHED', readyForAgentRuns: false,
+    limits: ['Build-time node_modules are shared from the locked checkout; this is not agent isolation.',
+      'Synthetic save controls are not an asynchronous backend or complete task flow.', 'Vendor defaults, contrast, and existing-system exceptions still require human review.'] };
+  let server, browser;
+  try {
+    const built = await build(root, plan, fromDemo);
+    report.build = { javascript: sha256(built.javascript), css: sha256(built.css) };
+    server = createServer((request, response) => {
+      const url = new URL(request.url, 'http://127.0.0.1');
+      if (url.pathname === '/probe.js') { response.writeHead(200, { 'content-type': 'text/javascript' }).end(built.javascript); return; }
+      if (url.pathname !== '/') { response.writeHead(404).end(); return; }
+      const mutation = url.searchParams.get('case');
+      const defect = { 'missing-height-override': '.min-h-11{min-height:0!important}', 'missing-recipe': '[data-styleseed-recipe]{--ss-control-radius:0px}', 'missing-theme': ':root{--brand:initial}' }[mutation] ?? '';
+      response.writeHead(200, { 'content-type': 'text/html' }).end(`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><link rel="icon" href="data:,"><title>Component integration probe</title><style>${built.css}\n${defect}</style></head><body><div id="root"></div><script src="/probe.js"></script></body></html>`);
+    });
+    server.listen(0, '127.0.0.1'); await once(server, 'listening');
+    browser = await fromDemo('playwright').chromium.launch({ headless: true }); report.versions.chromium = browser.version();
+    for (const id of ['desktop', 'mobile', ...Object.keys(mutations)]) report.runs.push(await exercise(browser, `http://127.0.0.1:${server.address().port}`, output, id));
+    report.calibration = summarize(report.runs); report.status = report.calibration.status;
+  } catch (error) { report.errors.push(error.stack || error.message); report.status = 'fail'; }
+  finally {
+    if (browser) await browser.close();
+    if (server?.listening) await new Promise(done => server.close(done));
+    try { assert.equal(buildPilotPlan().manifest.inputHash, report.inputHash); assert.deepEqual(sourceInventory(repo, probeSources), sources); }
+    catch (error) { report.errors.push(`Inputs changed during probe: ${error.message}`); report.status = 'fail'; }
+    writeReport(output, report);
+  }
+  console.log(JSON.stringify({ status: report.status, output, runs: report.runs.map(run => ({ id: run.id, failedChecks: run.failedChecks, environment: run.environment })), calibration: report.calibration, errors: report.errors, agentRuns: report.agentRuns, compatibilityApproval: report.compatibilityApproval }, null, 2));
+  if (report.status !== 'pass') process.exitCode = 1;
+}
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  try { await main(process.argv.slice(2)); } catch (error) { console.error(error.stack || error.message); process.exitCode = 1; }
+}

--- a/scripts/verify-repo.mjs
+++ b/scripts/verify-repo.mjs
@@ -83,6 +83,7 @@ if (!flags.has("--core")) {
   run(flags.has("--webpack") ? "Build demo with Webpack" : "Build demo with Turbopack", npmCommand, buildArgs, demoRoot);
   if (flags.has("--browser")) {
     run("Run browser smoke tests", npmCommand, ["run", "test:browser"], demoRoot);
+    run("Check pilot React and CSS integration", node, ["scripts/test-design-pilot-library.mjs"]);
     run("Calibrate design-pilot browser acceptance", node, ["scripts/test-design-pilot-browser.mjs", "--calibrate"]);
   }
 }


### PR DESCRIPTION
## Summary

Add a bounded, operator-only compatibility rehearsal before the design-judgment model pilot. It compiles the actual shared React primitives, condition C API examples, and Tailwind/theme/recipe CSS, then exercises them in Chromium. No dependencies are added or installed by the runner.

The first real render reproduced a concrete integration gap: the example Input inherited the vendor 4px radius while the selected enterprise-workbench recipe used 3px. Add the existing `ss-pattern-control` class at the example usage site. Vendor components and theme bytes remain unchanged and identical across arms.

## Verification

- `node scripts/verify-repo.mjs --webpack --browser`: passed locally, 112 runtime tests, production build, public-route smoke, React/CSS probe, and existing browser evaluator calibration.
- Nine check groups at desktop and 390×844: target size, recipe radius, brand token, containment, error/label relationship, controlled input, keyboard focus, busy-state click suppression/input retention, and table semantics.
- Three deliberately broken CSS cases must fail their designated check; environmental failures, missing checks/screenshots and unrelated failures cannot count as detections.
- Existing browser calibration remains 70 normal cases, 15 detected defects and five boundary probes.
- Added CLI/no-execution, fail-closed summary, unchanged library, and operator/arm isolation regressions.
- Ubuntu CI and future release preparation run the probe and retain report/PNGs only. The temporary dependency link/build workspace is not uploaded. Windows runs dependency-free contracts, not the Chromium probe.

## Boundaries

This is not a completed three-screen candidate, autonomous-agent comparison, expert approval, complete accessibility audit, or quality-improvement result. `readyForAgentRuns` remains false; actual reviewers, approved rubric/library, isolated model runtime and budget still need authorization. Build-time dependencies are reused from the locked checkout, not presented as an isolated agent environment.

No core runtime, version, published v4.2.0 tag/assets, or public performance claim is changed.
